### PR TITLE
Add Turkey Giveaway 2025 event page

### DIFF
--- a/turkey-giveaway.html
+++ b/turkey-giveaway.html
@@ -1,0 +1,75 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>9th Annual Turkey Giveaway – 2025</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;800&display=swap" rel="stylesheet">
+  <style>
+    body { font-family: 'Inter', sans-serif; }
+  </style>
+</head>
+<body class="bg-white text-gray-800">
+  <header class="sticky top-0 bg-white backdrop-blur shadow z-50">
+    <div class="max-w-7xl mx-auto px-4 py-4 flex justify-between items-center">
+      <div class="flex items-center">
+        <img src="images/bnf_logo.png" alt="BNF Logo" class="h-20 bg-white p-2 rounded shadow mr-3">
+        <span class="text-xl font-bold text-green-700">Bridge Niagara Foundation</span>
+      </div>
+      <nav class="hidden md:block">
+        <ul class="flex gap-4 text-sm md:text-base items-center">
+          <li><a href="index.html">Home</a></li>
+          <li><a href="about.html">About</a></li>
+          <li><a href="programs.html">Programs</a></li>
+          <li><a href="volunteer.html">Volunteer</a></li>
+          <li><a href="donate.html" class="bg-red-600 text-white px-4 py-2 rounded shadow hover:bg-red-700 transition">Donate</a></li>
+          <li><a href="contact.html">Contact</a></li>
+          <li><a href="faq.html">FAQ</a></li>
+        </ul>
+      </nav>
+    </div>
+  </header>
+
+  <main class="max-w-3xl mx-auto px-4 py-12">
+    <h1 class="text-3xl font-bold text-green-700 mb-6 text-center">9th Annual Turkey Giveaway – 2025</h1>
+    <p class="text-gray-700 mb-6 text-center">Distribute 1,000 turkeys, making it the largest giveaway in Western New York.</p>
+    <div class="space-y-4">
+      <div>
+        <p class="font-semibold">Date/Time:</p>
+        <p>Thursday Nov 20, 2025 @ 4:30 p.m.</p>
+      </div>
+      <div>
+        <p class="font-semibold">Location:</p>
+        <p>Abate Elementary School, 1600 11th St, Niagara Falls, NY 14305.</p>
+      </div>
+      <div>
+        <p class="font-semibold">Sponsorship Tiers:</p>
+        <ul class="list-disc pl-6">
+          <li>$2,000</li>
+          <li>$1,500</li>
+          <li>$1,000</li>
+          <li>Other amounts are welcome.</li>
+        </ul>
+      </div>
+    </div>
+    <section class="mt-8 text-center space-y-4">
+      <h2 class="text-2xl font-semibold text-green-700">Support the Giveaway</h2>
+      <div class="flex flex-col sm:flex-row justify-center gap-4">
+        <a href="/donate.html?amount=2000" class="bg-red-600 hover:bg-red-700 text-white px-4 py-2 rounded shadow">Donate $2,000</a>
+        <a href="/donate.html?amount=1500" class="bg-red-600 hover:bg-red-700 text-white px-4 py-2 rounded shadow">Donate $1,500</a>
+        <a href="/donate.html?amount=1000" class="bg-red-600 hover:bg-red-700 text-white px-4 py-2 rounded shadow">Donate $1,000</a>
+      </div>
+      <p>Other amounts are welcome. <a href="/donate.html" class="text-green-700 underline">Donate another amount</a>.</p>
+      <p class="text-sm text-gray-600">Donations are tax-deductible and processed securely via Stripe.</p>
+    </section>
+  </main>
+
+  <footer class="bg-gray-100 py-6 mt-20 text-center text-sm text-gray-600">
+    &copy; 2025 Bridge Niagara Foundation |
+    <a href="mailto:info@bridgeniagara.org" class="text-green-700 underline">info@bridgeniagara.org</a>
+  </footer>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add turkey-giveaway event page with standard site header and footer
- include event details and sponsorship tiers
- add donation buttons for preset and custom amounts

## Testing
- `npm test` *(fails: package.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_68925dcdfb688327863c9864680216ff