### PR TITLE
Add Turkey Giveaway link to site navigation

### DIFF
--- a/about.html
+++ b/about.html
@@ -14,6 +14,7 @@
         <li><a href="index.html">Home</a></li>
         <li><a href="about.html">About</a></li>
         <li><a href="programs.html">Programs</a></li>
+        <li><a href="turkey-giveaway.html">Turkey Giveaway</a></li>
         <li><a href="volunteer.html">Volunteer</a></li>
         <li><a href="donate.html">Donate</a></li>
         <li><a href="contact.html">Contact</a></li>

--- a/contact.html
+++ b/contact.html
@@ -14,6 +14,7 @@
         <li><a href="index.html">Home</a></li>
         <li><a href="about.html">About</a></li>
         <li><a href="programs.html">Programs</a></li>
+        <li><a href="turkey-giveaway.html">Turkey Giveaway</a></li>
         <li><a href="volunteer.html">Volunteer</a></li>
         <li><a href="donate.html">Donate</a></li>
         <li><a href="contact.html">Contact</a></li>

--- a/donate.html
+++ b/donate.html
@@ -21,6 +21,7 @@
           <li><a href="index.html">Home</a></li>
           <li><a href="about.html">About</a></li>
           <li><a href="programs.html">Programs</a></li>
+          <li><a href="turkey-giveaway.html">Turkey Giveaway</a></li>
           <li><a href="volunteer.html">Volunteer</a></li>
           <li><a href="donate.html" class="bg-red-600 text-white px-4 py-2 rounded shadow hover:bg-red-700 transition">Donate</a></li>
           <li><a href="contact.html">Contact</a></li>

--- a/faq.html
+++ b/faq.html
@@ -21,6 +21,7 @@
           <li><a href="index.html">Home</a></li>
           <li><a href="about.html">About</a></li>
           <li><a href="programs.html">Programs</a></li>
+          <li><a href="turkey-giveaway.html">Turkey Giveaway</a></li>
           <li><a href="volunteer.html">Volunteer</a></li>
           <li><a href="donate.html" class="bg-red-600 text-white px-4 py-2 rounded shadow hover:bg-red-700 transition">Donate</a></li>
           <li><a href="contact.html">Contact</a></li>

--- a/index.html
+++ b/index.html
@@ -24,6 +24,7 @@
           <li><a href="index.html">Home</a></li>
           <li><a href="about.html">About</a></li>
           <li><a href="programs.html">Programs</a></li>
+          <li><a href="turkey-giveaway.html">Turkey Giveaway</a></li>
           <li><a href="volunteer.html">Volunteer</a></li>
           <li><a href="donate.html" class="bg-red-600 text-white px-4 py-2 rounded shadow hover:bg-red-700 transition">Donate</a></li>
           <li><a href="contact.html">Contact</a></li>

--- a/programs.html
+++ b/programs.html
@@ -14,6 +14,7 @@
         <li><a href="index.html">Home</a></li>
         <li><a href="about.html">About</a></li>
         <li><a href="programs.html">Programs</a></li>
+        <li><a href="turkey-giveaway.html">Turkey Giveaway</a></li>
         <li><a href="volunteer.html">Volunteer</a></li>
         <li><a href="donate.html">Donate</a></li>
         <li><a href="contact.html">Contact</a></li>

--- a/success.html
+++ b/success.html
@@ -8,16 +8,38 @@
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;800&display=swap" rel="stylesheet">
   <style>body { font-family: 'Inter', sans-serif; }</style>
 </head>
-<body class="bg-gray-50 min-h-screen flex flex-col justify-center items-center px-4">
-  <div class="max-w-xl text-center">
-    <h1 class="text-4xl font-bold text-green-700 mb-4">Thank You for Your Donation!</h1>
-    <p class="text-lg text-gray-700 mb-6">
-      Your generous gift helps us continue supporting families and youth across the Niagara region.
-    </p>
-    <p class="text-sm text-gray-600 mb-6">
-      If you provided your email, a receipt has been sent to you. If you have any questions, feel free to contact us at <a href="mailto:info@bridgeniagara.org" class="text-green-700 font-medium">info@bridgeniagara.org</a>.
-    </p>
-    <a href="index.html" class="bg-green-700 hover:bg-green-800 text-white px-6 py-3 rounded shadow">Return to Home</a>
-  </div>
+<body class="bg-gray-50 text-gray-800 min-h-screen flex flex-col">
+  <header class="sticky top-0 bg-white backdrop-blur shadow z-50">
+    <div class="max-w-7xl mx-auto px-4 py-4 flex justify-between items-center">
+      <div class="flex items-center">
+        <img src="images/bnf_logo.png" alt="BNF Logo" class="h-20 bg-white p-2 rounded shadow mr-3">
+        <span class="text-xl font-bold text-green-700">Bridge Niagara Foundation</span>
+      </div>
+      <nav class="hidden md:block">
+        <ul class="flex gap-4 text-sm md:text-base items-center">
+          <li><a href="index.html">Home</a></li>
+          <li><a href="about.html">About</a></li>
+          <li><a href="programs.html">Programs</a></li>
+          <li><a href="turkey-giveaway.html">Turkey Giveaway</a></li>
+          <li><a href="volunteer.html">Volunteer</a></li>
+          <li><a href="donate.html" class="bg-red-600 text-white px-4 py-2 rounded shadow hover:bg-red-700 transition">Donate</a></li>
+          <li><a href="contact.html">Contact</a></li>
+          <li><a href="faq.html">FAQ</a></li>
+        </ul>
+      </nav>
+    </div>
+  </header>
+  <main class="flex-grow flex flex-col justify-center items-center px-4">
+    <div class="max-w-xl text-center">
+      <h1 class="text-4xl font-bold text-green-700 mb-4">Thank You for Your Donation!</h1>
+      <p class="text-lg text-gray-700 mb-6">
+        Your generous gift helps us continue supporting families and youth across the Niagara region.
+      </p>
+      <p class="text-sm text-gray-600 mb-6">
+        If you provided your email, a receipt has been sent to you. If you have any questions, feel free to contact us at <a href="mailto:info@bridgeniagara.org" class="text-green-700 font-medium">info@bridgeniagara.org</a>.
+      </p>
+      <a href="index.html" class="bg-green-700 hover:bg-green-800 text-white px-6 py-3 rounded shadow">Return to Home</a>
+    </div>
+  </main>
 </body>
 </html>

--- a/volunteer.html
+++ b/volunteer.html
@@ -21,6 +21,7 @@
           <li><a href="index.html">Home</a></li>
           <li><a href="about.html">About</a></li>
           <li><a href="programs.html">Programs</a></li>
+          <li><a href="turkey-giveaway.html">Turkey Giveaway</a></li>
           <li><a href="volunteer.html">Volunteer</a></li>
           <li><a href="donate.html" class="bg-red-600 text-white px-4 py-2 rounded shadow hover:bg-red-700 transition">Donate</a></li>
           <li><a href="contact.html">Contact</a></li>


### PR DESCRIPTION
## Summary
- add Turkey Giveaway page link near Programs in site navigation
- include navigation on donation success page

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68925dcf9fdc8327b3751b22856e427c