### PR TITLE
Add Turkey Giveaway navigation link to event page

### DIFF
--- a/turkey-giveaway.html
+++ b/turkey-giveaway.html
@@ -24,6 +24,7 @@
         <ul class="flex gap-4 text-sm md:text-base items-center">
           <li><a href="index.html">Home</a></li>
           <li><a href="about.html">About</a></li>
+          <li><a href="turkey-giveaway.html">Turkey Giveaway</a></li>
           <li><a href="volunteer.html">Volunteer</a></li>
           <li><a href="donate.html" class="bg-red-600 text-white px-4 py-2 rounded shadow hover:bg-red-700 transition">Donate</a></li>
           <li><a href="contact.html">Contact</a></li>


### PR DESCRIPTION
## Summary
- include Turkey Giveaway link in event page header navigation

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68926c2ce4d88327a5573890e80beca8