### PR TITLE
Expand mission statement and story on About page

### DIFF
--- a/about.html
+++ b/about.html
@@ -26,10 +26,14 @@
 <main class="container mx-auto px-4 py-10 space-y-6">
   <h1 class="text-4xl font-extrabold text-green-700 mb-6">About Us</h1>
   <section><h2 class="text-2xl font-semibold mb-2">Our Mission</h2>
-    <p class="text-lg">Bridge Niagara Foundation improves lives in Niagara County through education, wellness, and opportunity. We serve the underrepresented and under-resourced communities of Western New York through outreach programs, community support, and youth engagement. Join us in bridging the gap with dignity, service, and love.</p>
+    <p class="text-lg">Bridge Niagara Foundation exists to build a more just and connected Niagara County by linking neighbors to the resources they deserve.</p>
+    <p class="text-lg mt-2">We promote lifelong learning, invest in health and wellness, and open doors to meaningful opportunities. Through outreach programs, community partnerships, and youth engagement, we help families overcome barriers and pursue their dreams.</p>
+    <p class="text-lg mt-2">Driven by compassion and a belief in the dignity of every person, we work to bridge gaps with service, respect, and love.</p>
   </section>
   <section><h2 class="text-2xl font-semibold mt-8 mb-2">Our Story</h2>
-    <p class="text-lg">Founded by Anas Mangla and Nasreen Akhtar, rooted in decades of service to local communities.</p>
+    <p class="text-lg">Bridge Niagara grew from the shared vision of founders Anas Mangla and Nasreen Akhtar, who witnessed too many families struggling without a safety net.</p>
+    <p class="text-lg mt-2">For decades they volunteered, advocated, and built relationships across Western New York. These experiences revealed that lasting change happens when neighbors help neighbors, so they created a foundation dedicated to bringing people together.</p>
+    <p class="text-lg mt-2">Today, with the support of a diverse board and committed volunteers, we continue their tradition of service by organizing community events, connecting residents to essential services, and inspiring the next generation to uplift others.</p>
   </section>
   <section><h2 class="text-2xl font-semibold mt-8 mb-2">Board of Directors</h2>
     <div class="overflow-x-auto">


### PR DESCRIPTION
## Summary
- Broadened the About page mission statement to emphasize community connection, education, wellness, and compassion.
- Added a richer narrative about the founders' motivations and ongoing work in Western New York.

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68926d8bb7548327baffbdf69a449073