### PR TITLE
Document Stripe environment setup and ignore env file

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,5 @@
+# Copy this file to .env and fill in the values.
+
+# Stripe secret key for local development
+STRIPE_SECRET_KEY=sk_test_yourkeyhere
+

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+# Ignore environment files
+.env
+
+# Node dependencies
+node_modules/
+
+# Other
+.DS_Store
+

--- a/README.md
+++ b/README.md
@@ -1,0 +1,16 @@
+# BridgeNiagara
+
+This repository contains static site assets for Bridge Niagara.
+
+## Environment Variables
+
+Sensitive credentials should be stored in a local `.env` file which is ignored by git. An example file is provided as `.env.example`.
+
+```
+STRIPE_SECRET_KEY=sk_test_yourkeyhere
+```
+
+- Never commit the `.env` file. 
+- In production, configure `STRIPE_SECRET_KEY` through your hosting provider's environment settings.
+- Use the publishable key (`pk_test…`) only for client-side Stripe SDK usage when added.
+


### PR DESCRIPTION
## Summary
- Ignore local `.env` files in version control
- Provide `.env.example` with `STRIPE_SECRET_KEY` placeholder
- Document Stripe key usage and environment configuration

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68926ffb50648327b0cef13aa0cef469