### PR TITLE
Handle donation form via local checkout session

### DIFF
--- a/donate.html
+++ b/donate.html
@@ -15,7 +15,7 @@
   <main class="max-w-2xl mx-auto px-4 py-10">
     <h1 class="text-3xl font-bold text-green-700 mb-6 text-center">Support Our Mission</h1>
 
-    <form id="donation-form" action="https://bridge-donation.onrender.com/create-checkout-session" method="POST" class="space-y-6">
+    <form id="donation-form" action="/create-checkout-session" method="POST" class="space-y-6">
       <div>
         <label class="block text-lg font-semibold">Choose Amount</label>
         <div class="flex gap-4 mt-2">
@@ -82,6 +82,27 @@
         });
       });
     });
+  </script>
+  <script>
+  document.getElementById('donation-form').addEventListener('submit', async e => {
+    e.preventDefault();
+    const data = Object.fromEntries(new FormData(e.target).entries());
+    if (!data.amount) {
+      const custom = parseFloat(data.custom_amount || '0');
+      data.amount = Math.round(custom * 100);
+    } else {
+      data.amount = parseInt(data.amount, 10);
+    }
+    delete data.custom_amount;
+    data.mode = data.mode === 'subscription' ? 'subscription' : 'payment';
+    const res = await fetch('http://localhost:4242/create-checkout-session', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(data)
+    });
+    const { url } = await res.json();
+    window.location.href = url;
+  });
   </script>
 <script src="js/header.js"></script>
 </body>


### PR DESCRIPTION
## Summary
- route donation form to `/create-checkout-session`
- intercept form submission, send selection to local checkout session, and redirect to Stripe URL

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68926ffa01188327b8fde014b241bb18