### PR TITLE
Restrict CORS to configured origins

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,5 +7,8 @@ STRIPE_SECRET_KEY=sk_test_yourkeyhere
 SUCCESS_URL=https://your-static-site-domain/success.html
 CANCEL_URL=https://your-static-site-domain/cancel.html
 
+# Comma-separated list of allowed origins for CORS
+ALLOWED_ORIGINS=https://your-static-site-domain
+
 # Port for local server
 PORT=4242

--- a/server.js
+++ b/server.js
@@ -4,7 +4,22 @@ const cors = require('cors');
 const stripe = require('stripe')(process.env.STRIPE_SECRET_KEY);
 
 const app = express();
-app.use(cors());
+
+const allowedOrigins = process.env.ALLOWED_ORIGINS
+  ? process.env.ALLOWED_ORIGINS.split(',').map((o) => o.trim())
+  : [];
+
+const corsOptions = {
+  origin: (origin, callback) => {
+    if (!origin || allowedOrigins.includes(origin)) {
+      callback(null, true);
+    } else {
+      callback(new Error('Not allowed by CORS'));
+    }
+  },
+};
+
+app.use(cors(corsOptions));
 app.use(express.json());
 app.use(express.urlencoded({ extended: true }));
 


### PR DESCRIPTION
## Summary
- limit CORS access to origins listed in `ALLOWED_ORIGINS`
- document `ALLOWED_ORIGINS` in `.env.example`

## Testing
- `npm test` *(fails: Missing script "test")*
- `node --check server.js`


------
https://chatgpt.com/codex/tasks/task_e_6893b37d7fe48327baf58c7e41c6b529