### PR TITLE
Add Turkey Giveaway button to homepage hero

### DIFF
--- a/index.html
+++ b/index.html
@@ -23,7 +23,10 @@
         <div class="text-white max-w-3xl">
           <h1 class="text-4xl md:text-6xl font-extrabold mb-4">Empowering Families. Building Community.</h1>
           <p class="text-lg md:text-xl mb-6">Bridge Niagara Foundation connects resources with compassion to uplift those in need across Niagara Falls and beyond.</p>
-          <a href="donate.html" class="bg-red-600 hover:bg-red-700 text-white px-6 py-3 text-lg rounded shadow transition">Donate Now</a>
+          <div class="flex flex-col sm:flex-row gap-4 justify-center sm:justify-start">
+            <a href="donate.html" class="bg-red-600 hover:bg-red-700 text-white px-6 py-3 text-lg rounded shadow transition">Donate Now</a>
+            <a href="turkey-giveaway.html" class="bg-blue-600 hover:bg-blue-700 text-white px-6 py-3 text-lg rounded shadow transition">Turkey Giveaway Info</a>
+          </div>
         </div>
       </div>
     </section>


### PR DESCRIPTION
## Summary
- Add a Turkey Giveaway Info button next to the Donate Now button on the homepage hero section

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_6893bf40c6648327a8ec563a5f6fb320