### PR TITLE
refactor: externalize map key and improve contact map

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -16,10 +16,14 @@
 
 <main class="container mx-auto px-4 py-10">
   <h1 class="text-3xl font-bold text-green-700 mb-6">Contact Us</h1>
-  <iframe class="w-full h-80 rounded shadow-md border" loading="lazy" allowfullscreen
+  <iframe id="map" class="w-full h-80 rounded shadow-md border" loading="lazy" allowfullscreen
     referrerpolicy="no-referrer-when-downgrade"
-    src="https://www.google.com/maps/embed/v1/place?key=AIzaSyBcSwofl26LWQamNTT43DyYBlZ9qpQTIOk&q=6951+Williams+Road,+Niagara+Falls,+NY+14304">
+    title="Bridge Niagara Foundation location map">
+    <p class="p-4">Map cannot be displayed. View our location on
+      <a href="https://maps.google.com/?q=6951+Williams+Road,+Niagara+Falls,+NY+14304" class="text-blue-600 underline">Google Maps</a>.
+    </p>
   </iframe>
+  <p class="mt-2 text-sm">Can't view the map? Our address is 6951 Williams Road, Niagara Falls, NY 14304.</p>
   <div class="mt-6 text-lg">
     <p><strong>Address:</strong> 6951 Williams Road, Niagara Falls, NY 14304</p>
     <p><strong>Phone:</strong> (716) 531-2075</p>
@@ -32,4 +36,5 @@
   <a href="mailto:info@bridgeniagara.org" class="text-green-700 underline">info@bridgeniagara.org</a>
 </footer>
 <script src="js/header.js"></script>
+<script src="js/map.js"></script>
 </body></html>

--- a/js/map.js
+++ b/js/map.js
@@ -1,0 +1,16 @@
+window.addEventListener('DOMContentLoaded', () => {
+  fetch('/config')
+    .then((response) => response.json())
+    .then((config) => {
+      const iframe = document.getElementById('map');
+      if (iframe && config.mapsApiKey) {
+        const base = 'https://www.google.com/maps/embed/v1/place';
+        const params = new URLSearchParams({
+          key: config.mapsApiKey,
+          q: '6951 Williams Road, Niagara Falls, NY 14304'
+        });
+        iframe.src = `${base}?${params.toString()}`;
+      }
+    })
+    .catch((err) => console.error('Failed to load map:', err));
+});

--- a/server.js
+++ b/server.js
@@ -23,6 +23,10 @@ app.use(cors(corsOptions));
 app.use(express.json());
 app.use(express.urlencoded({ extended: true }));
 
+app.get('/config', (req, res) => {
+  res.json({ mapsApiKey: process.env.GOOGLE_MAPS_API_KEY || '' });
+});
+
 app.post('/create-checkout-session', async (req, res) => {
   try {
     const { amount, mode, name, email, phone } = req.body;


### PR DESCRIPTION
## Summary
- serve Google Maps API key from server-side config and remove hard-coded key from the contact page
- load the contact page map dynamically and provide fallback text for non-iframe users

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6893d1a2514483279b574ce2d5b8adb3