### PR TITLE
refactor: share footer markup

### DIFF
--- a/about.html
+++ b/about.html
@@ -70,9 +70,8 @@
   </section>
 </main>
 
-<footer class="bg-gray-100 py-6 mt-20 text-center text-sm text-gray-600">
-  &copy; 2025 Bridge Niagara Foundation |
-  <a href="mailto:info@bridgeniagara.org" class="text-green-700 underline">info@bridgeniagara.org</a>
-</footer>
+<div id="footer"></div>
 <script src="js/header.js"></script>
-</body></html>
+<script src="js/footer.js"></script>
+</body>
+</html>

--- a/cancel.html
+++ b/cancel.html
@@ -21,6 +21,8 @@
       <a href="donate.html" class="bg-red-600 hover:bg-red-700 text-white px-6 py-3 rounded shadow">Try Again</a>
     </div>
   </main>
+<div id="footer"></div>
 <script src="js/header.js"></script>
+<script src="js/footer.js"></script>
 </body>
 </html>

--- a/contact.html
+++ b/contact.html
@@ -27,9 +27,8 @@
   </div>
 </main>
 
-<footer class="bg-gray-100 py-6 mt-20 text-center text-sm text-gray-600">
-  &copy; 2025 Bridge Niagara Foundation |
-  <a href="mailto:info@bridgeniagara.org" class="text-green-700 underline">info@bridgeniagara.org</a>
-</footer>
+<div id="footer"></div>
 <script src="js/header.js"></script>
-</body></html>
+<script src="js/footer.js"></script>
+</body>
+</html>

--- a/donate.html
+++ b/donate.html
@@ -51,6 +51,7 @@
     </form>
   </main>
 
+<div id="footer"></div>
   <script>
     document.addEventListener('DOMContentLoaded', function () {
       const tabs = document.querySelectorAll('.donate-tab');
@@ -140,5 +141,6 @@
   </script>
 
   <script src="js/header.js"></script>
+<script src="js/footer.js"></script>
 </body>
 </html>

--- a/faq.html
+++ b/faq.html
@@ -83,6 +83,9 @@
       </form>
     </div>
   </main>
+
+<div id="footer"></div>
 <script src="js/header.js"></script>
+<script src="js/footer.js"></script>
 </body>
 </html>

--- a/footer.html
+++ b/footer.html
@@ -1,0 +1,4 @@
+<footer class="bg-gray-100 py-6 mt-20 text-center text-sm text-gray-600">
+  &copy; 2025 Bridge Niagara Foundation |
+  <a href="mailto:info@bridgeniagara.org" class="text-green-700 underline">info@bridgeniagara.org</a>
+</footer>

--- a/index.html
+++ b/index.html
@@ -32,6 +32,9 @@
     </section>
 
   </main>
+
+<div id="footer"></div>
 <script src="js/header.js"></script>
+<script src="js/footer.js"></script>
 </body>
 </html>

--- a/js/footer.js
+++ b/js/footer.js
@@ -1,0 +1,12 @@
+// Inject shared footer on pages
+window.addEventListener('DOMContentLoaded', () => {
+  fetch('footer.html')
+    .then((response) => response.text())
+    .then((html) => {
+      const container = document.getElementById('footer');
+      if (container) {
+        container.innerHTML = html;
+      }
+    })
+    .catch((err) => console.error('Failed to load footer:', err));
+});

--- a/success.html
+++ b/success.html
@@ -24,6 +24,9 @@
       <a href="index.html" class="bg-green-700 hover:bg-green-800 text-white px-6 py-3 rounded shadow">Return to Home</a>
     </div>
   </main>
+
+<div id="footer"></div>
 <script src="js/header.js"></script>
+<script src="js/footer.js"></script>
 </body>
 </html>

--- a/turkey-giveaway.html
+++ b/turkey-giveaway.html
@@ -73,10 +73,8 @@
     </section>
   </main>
 
-  <footer class="bg-gray-100 py-6 mt-20 text-center text-sm text-gray-600">
-    &copy; 2025 Bridge Niagara Foundation |
-    <a href="mailto:info@bridgeniagara.org" class="text-green-700 underline">info@bridgeniagara.org</a>
-  </footer>
+  <div id="footer"></div>
 <script src="js/header.js"></script>
+<script src="js/footer.js"></script>
 </body>
 </html>

--- a/volunteer.html
+++ b/volunteer.html
@@ -34,6 +34,9 @@
       <button type="submit" class="bg-green-700 hover:bg-green-800 text-white px-6 py-2 rounded">Submit</button>
     </form>
   </main>
+
+<div id="footer"></div>
 <script src="js/header.js"></script>
+<script src="js/footer.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- extract footer markup to new `footer.html`
- add `js/footer.js` to inject shared footer
- load shared footer on all pages

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6893d1a5d7708327a99c92f9cd8ea9e6