### PR TITLE
Improve CORS flexibility and add security middleware

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,8 @@
         "cors": "^2.8.5",
         "dotenv": "^16.4.5",
         "express": "^4.18.2",
+        "express-rate-limit": "^7.0.0",
+        "helmet": "^7.0.0",
         "stripe": "^12.0.0"
       },
       "devDependencies": {
@@ -1144,6 +1146,21 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/express-rate-limit": {
+      "version": "7.5.1",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-7.5.1.tgz",
+      "integrity": "sha512-7iN8iPMDzOMHPUYllBEsQdWVB6fPDMPqwjBaFrgr4Jgr/+okjvzAy+UHlYYL/Vs0OsOrMkwS6PJDkFlJwoxUnw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
     "node_modules/fill-range": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
@@ -1294,6 +1311,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/helmet": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/helmet/-/helmet-7.2.0.tgz",
+      "integrity": "sha512-ZRiwvN089JfMXokizgqEPXsl2Guk094yExfoDXR0cBYWxtBbaSww/w+vT4WEJsBW2iTUi1GgZ6swmoug3Oy4Xw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.0.0"
       }
     },
     "node_modules/http-errors": {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,9 @@
     "cors": "^2.8.5",
     "dotenv": "^16.4.5",
     "express": "^4.18.2",
-    "stripe": "^12.0.0"
+    "stripe": "^12.0.0",
+    "helmet": "^7.0.0",
+    "express-rate-limit": "^7.0.0"
   },
   "devDependencies": {
     "@tailwindcss/cli": "^4.1.11",

--- a/server.js
+++ b/server.js
@@ -1,6 +1,8 @@
 require('dotenv').config();
 const express = require('express');
 const cors = require('cors');
+const helmet = require('helmet');
+const rateLimit = require('express-rate-limit');
 const stripe = require('stripe')(process.env.STRIPE_SECRET_KEY);
 
 const app = express();
@@ -9,21 +11,31 @@ const allowedOrigins = process.env.ALLOWED_ORIGINS
   ? process.env.ALLOWED_ORIGINS.split(',').map((o) => o.trim())
   : [];
 
-const corsOptions = {
-  origin: (origin, callback) => {
-    if (!origin || allowedOrigins.includes(origin)) {
-      callback(null, true);
-    } else {
-      callback(new Error('Not allowed by CORS'));
-    }
-  },
-};
+const corsOptions = allowedOrigins.includes('*')
+  ? { origin: true }
+  : {
+      origin: (origin, callback) => {
+        if (!origin || allowedOrigins.includes(origin)) {
+          callback(null, true);
+        } else {
+          callback(new Error('Not allowed by CORS'));
+        }
+      },
+    };
 
 app.use(cors(corsOptions));
+app.use(helmet());
 app.use(express.json());
 app.use(express.urlencoded({ extended: true }));
 
-app.post('/create-checkout-session', async (req, res) => {
+const checkoutLimiter = rateLimit({
+  windowMs: 60 * 1000,
+  max: 5,
+  standardHeaders: true,
+  legacyHeaders: false,
+});
+
+app.post('/create-checkout-session', checkoutLimiter, async (req, res) => {
   try {
     const { amount, mode, name, email, phone } = req.body;
     const donationAmount = parseInt(amount, 10);


### PR DESCRIPTION
## Summary
- allow wildcard origins when `ALLOWED_ORIGINS` contains `*`
- add Helmet for standard security headers
- throttle checkout sessions with rate limiting

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6893d1aa26cc832787bef2c0bbc18a1a