### PR TITLE
Add form submission endpoint and feedback

### DIFF
--- a/faq.html
+++ b/faq.html
@@ -66,7 +66,7 @@
 
     <div class="mt-12 pt-8 border-t">
       <h2 class="text-2xl font-semibold text-green-700 mb-4">Still Have Questions?</h2>
-      <form action="#" method="POST" class="space-y-4">
+      <form id="faq-form" action="/submit-form" method="POST" class="space-y-4">
         <div>
           <label for="faq-name" class="block font-medium">Your Name</label>
           <input type="text" id="faq-name" name="faq-name" required class="w-full border px-4 py-2">
@@ -77,12 +77,48 @@
         </div>
         <div>
           <label for="faq-question" class="block font-medium">Your Question</label>
-          <textarea id="faq-question" name="faq-question" rows="4" class="w-full border px-4 py-2"></textarea>
+          <textarea id="faq-question" name="faq-question" rows="4" required class="w-full border px-4 py-2"></textarea>
         </div>
         <button type="submit" class="bg-green-700 hover:bg-green-800 text-white px-6 py-2 rounded">Submit</button>
       </form>
+      <p id="faq-status" class="text-sm mt-2"></p>
     </div>
   </main>
+<script>
+  const faqForm = document.getElementById('faq-form');
+  const faqStatus = document.getElementById('faq-status');
+  faqForm.addEventListener('submit', async (e) => {
+    e.preventDefault();
+    if (!faqForm.checkValidity()) {
+      faqForm.reportValidity();
+      return;
+    }
+    const data = {
+      name: document.getElementById('faq-name').value,
+      email: document.getElementById('faq-email').value,
+      message: document.getElementById('faq-question').value,
+      formType: 'question'
+    };
+    try {
+      const res = await fetch(faqForm.action, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(data)
+      });
+      if (res.ok) {
+        faqStatus.textContent = 'Thanks for your question! We will respond soon.';
+        faqStatus.className = 'text-green-700 mt-2';
+        faqForm.reset();
+      } else {
+        faqStatus.textContent = 'Submission failed. Please try again.';
+        faqStatus.className = 'text-red-700 mt-2';
+      }
+    } catch (err) {
+      faqStatus.textContent = 'An error occurred. Please try again.';
+      faqStatus.className = 'text-red-700 mt-2';
+    }
+  });
+</script>
 <script src="js/header.js"></script>
 </body>
 </html>

--- a/server.js
+++ b/server.js
@@ -59,5 +59,14 @@ app.post('/create-checkout-session', async (req, res) => {
   }
 });
 
+app.post('/submit-form', (req, res) => {
+  const { name, email, message, formType } = req.body;
+  if (!name || !email) {
+    return res.status(400).json({ error: 'Name and email are required.' });
+  }
+  console.log(`Form submission (${formType || 'general'}):`, { name, email, message });
+  res.json({ success: true });
+});
+
 const port = process.env.PORT || 4242;
 app.listen(port, () => console.log(`Server running on port ${port}`));

--- a/volunteer.html
+++ b/volunteer.html
@@ -18,7 +18,7 @@
     <h1 class="text-3xl font-bold text-green-700 mb-4">Volunteer with Us</h1>
     <p class="text-gray-700 mb-6">We welcome individuals of all ages and backgrounds to help out with our programs, events, and outreach efforts. Fill out the form below and we’ll reach out with upcoming opportunities.</p>
 
-    <form action="#" method="POST" class="space-y-4">
+    <form id="volunteer-form" action="/submit-form" method="POST" class="space-y-4">
       <div>
         <label for="name" class="block font-medium">Full Name</label>
         <input type="text" id="name" name="name" required class="w-full border px-4 py-2">
@@ -33,7 +33,39 @@
       </div>
       <button type="submit" class="bg-green-700 hover:bg-green-800 text-white px-6 py-2 rounded">Submit</button>
     </form>
+    <p id="volunteer-status" class="text-sm mt-2"></p>
   </main>
+<script>
+  const volunteerForm = document.getElementById('volunteer-form');
+  const volunteerStatus = document.getElementById('volunteer-status');
+  volunteerForm.addEventListener('submit', async (e) => {
+    e.preventDefault();
+    if (!volunteerForm.checkValidity()) {
+      volunteerForm.reportValidity();
+      return;
+    }
+    const data = Object.fromEntries(new FormData(volunteerForm).entries());
+    data.formType = 'volunteer';
+    try {
+      const res = await fetch(volunteerForm.action, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(data)
+      });
+      if (res.ok) {
+        volunteerStatus.textContent = 'Thank you for volunteering! We will contact you soon.';
+        volunteerStatus.className = 'text-green-700 mt-2';
+        volunteerForm.reset();
+      } else {
+        volunteerStatus.textContent = 'Submission failed. Please try again.';
+        volunteerStatus.className = 'text-red-700 mt-2';
+      }
+    } catch (err) {
+      volunteerStatus.textContent = 'An error occurred. Please try again.';
+      volunteerStatus.className = 'text-red-700 mt-2';
+    }
+  });
+</script>
 <script src="js/header.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add `/submit-form` API route to process basic form submissions
- wire volunteer and FAQ pages to the new endpoint with client-side validation
- show success and error messages after form submission

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6893d1ab6e6c8327b57801aaeb31348a