### PR TITLE
docs: add setup and testing instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,14 @@
 
 This repository contains static site assets for Bridge Niagara.
 
+## Installing Dependencies
+
+Install the required Node.js packages:
+
+```
+npm install
+```
+
 ## Environment Variables
 
 Sensitive credentials should be stored in a local `.env` file which is ignored by git. An example file is provided as `.env.example`.
@@ -17,6 +25,22 @@ PORT=4242
 - In production, configure these values through your hosting provider's environment settings.
 - Use the publishable key (`pk_test…`) only for client-side Stripe SDK usage when added.
 
+## Running the Express server
+
+Start the development server:
+
+```
+npm start
+```
+
+## Running Tests
+
+Execute the test suite:
+
+```
+npm test
+```
+
 ## Building CSS
 
 This site uses Tailwind CSS. Generate the stylesheet before deploying:
@@ -28,4 +52,12 @@ npm run build:css
 ## Deployment
 
 Run the Tailwind build command above before publishing the site to ensure `css/tailwind.css` is up to date.
+
+## Contributing
+
+Pull requests are welcome. Please run `npm test` and `npm run build:css` before submitting.
+
+## CI / Deployment
+
+In continuous integration or deployment pipelines, run the tests and CSS build before releasing changes.
 


### PR DESCRIPTION
## Summary
- document how to install Node.js dependencies
- clarify how to run the Express server and tests
- add contributing and CI/deployment guidance

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6893d1ad3ffc8327b4b0458927d765a0