### PR TITLE
Use configured backend URL

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,6 +7,9 @@ STRIPE_SECRET_KEY=sk_test_yourkeyhere
 SUCCESS_URL=https://your-static-site-domain/success.html
 CANCEL_URL=https://your-static-site-domain/cancel.html
 
+# Base URL of the backend server handling donations
+SERVER_URL=https://your-backend-domain
+
 # Comma-separated list of allowed origins for CORS
 ALLOWED_ORIGINS=https://your-static-site-domain
 

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ node_modules/
 
 # Other
 .DS_Store
+
+# Frontend configuration generated per deployment
+js/config.js

--- a/README.md
+++ b/README.md
@@ -18,12 +18,15 @@ Sensitive credentials should be stored in a local `.env` file which is ignored b
 STRIPE_SECRET_KEY=sk_test_yourkeyhere
 SUCCESS_URL=https://your-domain.example/success.html
 CANCEL_URL=https://your-domain.example/cancel.html
+SERVER_URL=https://your-backend-domain
 PORT=4242
 ```
 
 - Never commit the `.env` file.
 - In production, configure these values through your hosting provider's environment settings.
 - Use the publishable key (`pk_test…`) only for client-side Stripe SDK usage when added.
+- The donation page requires a valid backend URL. Copy `js/config.example.js` to `js/config.js` and
+  set `window.SERVER_URL` to match `SERVER_URL` above or define `SERVER_URL` via your build system.
 
 ## Running the Express server
 

--- a/donate.html
+++ b/donate.html
@@ -61,6 +61,7 @@
     </form>
   </main>
 
+  <script src="js/config.js"></script>
   <script src="js/donationHelpers.js"></script>
   <script>
     document.addEventListener('DOMContentLoaded', function () {
@@ -87,11 +88,15 @@
         });
       }
 
-      // Determine base URL from environment or current origin
+      // Determine backend base URL from configuration
       const SERVER_URL =
         (typeof window !== 'undefined' && window.SERVER_URL) ||
-        (typeof process !== 'undefined' && process.env && process.env.SERVER_URL) ||
-        window.location.origin;
+        (typeof process !== 'undefined' && process.env && process.env.SERVER_URL);
+
+      if (!SERVER_URL) {
+        console.error('SERVER_URL is not defined');
+        return;
+      }
 
       // Prefill donation amount from query parameter
       const params = new URLSearchParams(window.location.search);

--- a/js/config.example.js
+++ b/js/config.example.js
@@ -1,0 +1,1 @@
+window.SERVER_URL = 'https://your-backend-domain';

--- a/js/donate.js
+++ b/js/donate.js
@@ -23,11 +23,15 @@ window.addEventListener('DOMContentLoaded', () => {
     });
   }
 
-  // Determine base URL from environment or current origin
+  // Determine backend base URL from configuration
   const SERVER_URL =
     (typeof window !== 'undefined' && window.SERVER_URL) ||
-    (typeof process !== 'undefined' && process.env && process.env.SERVER_URL) ||
-    window.location.origin;
+    (typeof process !== 'undefined' && process.env && process.env.SERVER_URL);
+
+  if (!SERVER_URL) {
+    console.error('SERVER_URL is not defined');
+    return;
+  }
 
   // Prefill donation amount from query parameter
   const params = new URLSearchParams(window.location.search);


### PR DESCRIPTION
## Summary
- add SERVER_URL to environment example
- load donation backend from config and drop origin fallback
- document deployment requirement for backend URL

## Testing
- `npm test`
- `npm run build:css`


------
https://chatgpt.com/codex/tasks/task_e_68940cae57cc8327a05ec4bdbe41c4d0