### PR TITLE
Add custom stylesheet for shared overrides

### DIFF
--- a/about.html
+++ b/about.html
@@ -15,10 +15,10 @@
   <meta name="twitter:image" content="https://bridgeniagara.org/images/bnf_logo.png" />
   <title>About Us - Bridge Niagara Foundation</title>
   <link rel="stylesheet" href="css/tailwind.css" />
+  <link rel="stylesheet" href="css/custom.css" />
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;800&display=swap" rel="stylesheet">
-  <style>body { font-family: 'Inter', sans-serif; }</style>
 </head>
 <body class="bg-white text-gray-800">
 

--- a/cancel.html
+++ b/cancel.html
@@ -15,10 +15,10 @@
   <meta name="twitter:image" content="https://bridgeniagara.org/images/bnf_logo.png" />
   <title>Donation Cancelled - Bridge Niagara</title>
   <link rel="stylesheet" href="css/tailwind.css" />
+  <link rel="stylesheet" href="css/custom.css" />
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;800&display=swap" rel="stylesheet">
-  <style>body { font-family: 'Inter', sans-serif; }</style>
 </head>
 <body class="bg-gray-50 text-gray-800 min-h-screen flex flex-col">
   <div id="header"></div>

--- a/contact.html
+++ b/contact.html
@@ -15,10 +15,10 @@
   <meta name="twitter:image" content="https://bridgeniagara.org/images/bnf_logo.png" />
   <title>Contact Us - Bridge Niagara Foundation</title>
   <link rel="stylesheet" href="css/tailwind.css" />
+  <link rel="stylesheet" href="css/custom.css" />
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;800&display=swap" rel="stylesheet">
-  <style>body { font-family: 'Inter', sans-serif; }</style>
 </head>
 <body class="bg-white text-gray-800">
 

--- a/css/custom.css
+++ b/css/custom.css
@@ -1,0 +1,30 @@
+/* Custom overrides for Tailwind-generated styles */
+
+body {
+  font-family: 'Inter', sans-serif;
+}
+
+/* Restored donation button style */
+.donate-btn {
+  background-color: #dc2626; /* red-600 */
+  color: #fff;
+  padding: 0.75rem 1.5rem; /* py-3 px-6 */
+  border-radius: 0.25rem; /* rounded */
+  box-shadow: 0 1px 2px 0 rgba(0, 0, 0, 0.05); /* shadow */
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem; /* gap-2 */
+  width: 100%;
+  transition: background-color 0.2s ease;
+}
+
+.donate-btn:hover {
+  background-color: #b91c1c; /* red-700 */
+}
+
+@media (min-width: 640px) {
+  .donate-btn {
+    width: auto; /* sm:w-auto */
+  }
+}

--- a/donate.html
+++ b/donate.html
@@ -15,10 +15,10 @@
   <meta name="twitter:image" content="https://bridgeniagara.org/images/bnf_logo.png" />
   <title>Donate - Bridge Niagara Foundation</title>
   <link rel="stylesheet" href="css/tailwind.css" />
+  <link rel="stylesheet" href="css/custom.css" />
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;800&display=swap" rel="stylesheet" />
-  <style>body { font-family: 'Inter', sans-serif; }</style>
 </head>
 <body class="bg-white text-gray-800">
   <!-- Consistent Navigation Bar -->

--- a/faq.html
+++ b/faq.html
@@ -15,10 +15,10 @@
   <meta name="twitter:image" content="https://bridgeniagara.org/images/bnf_logo.png" />
   <title>FAQ - Bridge Niagara</title>
   <link rel="stylesheet" href="css/tailwind.css" />
+  <link rel="stylesheet" href="css/custom.css" />
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;800&display=swap" rel="stylesheet">
-  <style>body { font-family: 'Inter', sans-serif; }</style>
 </head>
 <body class="bg-white text-gray-800">
   <!-- Navigation -->

--- a/index.html
+++ b/index.html
@@ -15,12 +15,10 @@
   <meta name="twitter:image" content="https://bridgeniagara.org/images/bnf_logo.png" />
   <title>Bridge Niagara Foundation</title>
   <link rel="stylesheet" href="css/tailwind.css" />
+  <link rel="stylesheet" href="css/custom.css" />
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;800&display=swap" rel="stylesheet">
-  <style>
-    body { font-family: 'Inter', sans-serif; }
-  </style>
 </head>
 <body class="bg-white text-gray-800">
   <div id="header"></div>

--- a/success.html
+++ b/success.html
@@ -15,10 +15,10 @@
   <meta name="twitter:image" content="https://bridgeniagara.org/images/bnf_logo.png" />
   <title>Thank You - Bridge Niagara</title>
   <link rel="stylesheet" href="css/tailwind.css" />
+  <link rel="stylesheet" href="css/custom.css" />
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;800&display=swap" rel="stylesheet">
-  <style>body { font-family: 'Inter', sans-serif; }</style>
 </head>
 <body class="bg-gray-50 text-gray-800 min-h-screen flex flex-col">
   <div id="header"></div>

--- a/turkey-giveaway.html
+++ b/turkey-giveaway.html
@@ -15,12 +15,10 @@
   <meta name="twitter:image" content="https://bridgeniagara.org/images/bnf_logo.png" />
   <title>9th Annual Turkey Giveaway – 2025</title>
   <link rel="stylesheet" href="css/tailwind.css" />
+  <link rel="stylesheet" href="css/custom.css" />
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;800&display=swap" rel="stylesheet">
-  <style>
-    body { font-family: 'Inter', sans-serif; }
-  </style>
 </head>
 <body class="bg-white text-gray-800">
   <div id="header"></div>

--- a/volunteer.html
+++ b/volunteer.html
@@ -15,10 +15,10 @@
   <meta name="twitter:image" content="https://bridgeniagara.org/images/bnf_logo.png" />
   <title>Volunteer - Bridge Niagara Foundation</title>
   <link rel="stylesheet" href="css/tailwind.css" />
+  <link rel="stylesheet" href="css/custom.css" />
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;800&display=swap" rel="stylesheet">
-  <style>body { font-family: 'Inter', sans-serif; }</style>
 </head>
 <body class="bg-white text-gray-800">
   <!-- Navigation -->


### PR DESCRIPTION
## Summary
- restore bespoke `.donate-btn` styling in new `css/custom.css`
- centralize Inter font overrides and reference `custom.css` on all pages

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68940e33c1a483278421535c08a9671e