### PR TITLE
Load Tailwind CSS from CDN in static pages

### DIFF
--- a/about.html
+++ b/about.html
@@ -14,7 +14,7 @@
   <meta name="twitter:description" content="Learn about Bridge Niagara Foundation's mission, story, and board working to build a more just and connected Niagara County." />
   <meta name="twitter:image" content="https://bridgeniagara.org/images/bnf_logo.png" />
   <title>About Us - Bridge Niagara Foundation</title>
-  <link rel="stylesheet" href="css/tailwind.css" />
+  <script src="https://cdn.tailwindcss.com"></script>
   <link rel="stylesheet" href="css/custom.css" />
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/cancel.html
+++ b/cancel.html
@@ -14,7 +14,7 @@
   <meta name="twitter:description" content="Your Bridge Niagara Foundation donation was cancelled—no charges were made. Please try again or contact us for assistance." />
   <meta name="twitter:image" content="https://bridgeniagara.org/images/bnf_logo.png" />
   <title>Donation Cancelled - Bridge Niagara</title>
-  <link rel="stylesheet" href="css/tailwind.css" />
+  <script src="https://cdn.tailwindcss.com"></script>
   <link rel="stylesheet" href="css/custom.css" />
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/contact.html
+++ b/contact.html
@@ -14,7 +14,7 @@
   <meta name="twitter:description" content="Get in touch with Bridge Niagara Foundation for questions, support, or directions to our Niagara Falls office." />
   <meta name="twitter:image" content="https://bridgeniagara.org/images/bnf_logo.png" />
   <title>Contact Us - Bridge Niagara Foundation</title>
-  <link rel="stylesheet" href="css/tailwind.css" />
+  <script src="https://cdn.tailwindcss.com"></script>
   <link rel="stylesheet" href="css/custom.css" />
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/donate.html
+++ b/donate.html
@@ -14,7 +14,7 @@
   <meta name="twitter:description" content="Support Bridge Niagara Foundation's programs by making a secure one-time or monthly donation through our online form." />
   <meta name="twitter:image" content="https://bridgeniagara.org/images/bnf_logo.png" />
   <title>Donate - Bridge Niagara Foundation</title>
-  <link rel="stylesheet" href="css/tailwind.css" />
+  <script src="https://cdn.tailwindcss.com"></script>
   <link rel="stylesheet" href="css/custom.css" />
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/faq.html
+++ b/faq.html
@@ -14,7 +14,7 @@
   <meta name="twitter:description" content="Find answers to common questions about donating, volunteering, and our community programs at Bridge Niagara Foundation." />
   <meta name="twitter:image" content="https://bridgeniagara.org/images/bnf_logo.png" />
   <title>FAQ - Bridge Niagara</title>
-  <link rel="stylesheet" href="css/tailwind.css" />
+  <script src="https://cdn.tailwindcss.com"></script>
   <link rel="stylesheet" href="css/custom.css" />
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/index.html
+++ b/index.html
@@ -14,7 +14,7 @@
   <meta name="twitter:description" content="Bridge Niagara Foundation connects resources with compassion to uplift Niagara Falls families through community programs and support." />
   <meta name="twitter:image" content="https://bridgeniagara.org/images/bnf_logo.png" />
   <title>Bridge Niagara Foundation</title>
-  <link rel="stylesheet" href="css/tailwind.css" />
+  <script src="https://cdn.tailwindcss.com"></script>
   <link rel="stylesheet" href="css/custom.css" />
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/success.html
+++ b/success.html
@@ -14,7 +14,7 @@
   <meta name="twitter:description" content="Thank you for donating to Bridge Niagara Foundation; your support empowers families and youth across the Niagara region." />
   <meta name="twitter:image" content="https://bridgeniagara.org/images/bnf_logo.png" />
   <title>Thank You - Bridge Niagara</title>
-  <link rel="stylesheet" href="css/tailwind.css" />
+  <script src="https://cdn.tailwindcss.com"></script>
   <link rel="stylesheet" href="css/custom.css" />
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/turkey-giveaway.html
+++ b/turkey-giveaway.html
@@ -14,7 +14,7 @@
   <meta name="twitter:description" content="Discover details about Bridge Niagara Foundation's 9th Annual Turkey Giveaway in 2025 and learn how to support the event." />
   <meta name="twitter:image" content="https://bridgeniagara.org/images/bnf_logo.png" />
   <title>9th Annual Turkey Giveaway – 2025</title>
-  <link rel="stylesheet" href="css/tailwind.css" />
+  <script src="https://cdn.tailwindcss.com"></script>
   <link rel="stylesheet" href="css/custom.css" />
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/volunteer.html
+++ b/volunteer.html
@@ -14,7 +14,7 @@
   <meta name="twitter:description" content="Join Bridge Niagara Foundation as a volunteer to support community events, outreach, and youth programs across Niagara." />
   <meta name="twitter:image" content="https://bridgeniagara.org/images/bnf_logo.png" />
   <title>Volunteer - Bridge Niagara Foundation</title>
-  <link rel="stylesheet" href="css/tailwind.css" />
+  <script src="https://cdn.tailwindcss.com"></script>
   <link rel="stylesheet" href="css/custom.css" />
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>


### PR DESCRIPTION
## Summary
- Replace local Tailwind stylesheet with CDN script across HTML pages
- Preserve custom CSS link for site-specific styling

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68941132c99c83278815267d12dc5e58