### PR TITLE
Handle default CORS origin and document ALLOWED_ORIGINS

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ SUCCESS_URL=https://your-domain.example/success.html
 CANCEL_URL=https://your-domain.example/cancel.html
 SERVER_URL=https://your-backend-domain
 PORT=4242
+ALLOWED_ORIGINS=https://your-frontend.example
 ```
 
 - Never commit the `.env` file.
@@ -27,6 +28,10 @@ PORT=4242
 - Use the publishable key (`pk_test…`) only for client-side Stripe SDK usage when added.
 - The donation page requires a valid backend URL. Copy `js/config.example.js` to `js/config.js` and
   set `window.SERVER_URL` to match `SERVER_URL` above or define `SERVER_URL` via your build system.
+
+If `ALLOWED_ORIGINS` is omitted, the server will automatically allow requests from the same origin as
+the page making the request. To restrict cross-origin requests, provide a comma-separated list of
+allowed origins or set `ALLOWED_ORIGINS=*` to permit any origin.
 
 ## Running the Express server
 

--- a/server.js
+++ b/server.js
@@ -11,11 +11,14 @@ const app = express();
 const limiter = rateLimit({ windowMs: 60 * 1000, max: 100 });
 app.use(limiter);
 
-const allowedOrigins = process.env.ALLOWED_ORIGINS
-  ? process.env.ALLOWED_ORIGINS.split(',').map((o) => o.trim())
-  : [];
+const envAllowedOrigins = process.env.ALLOWED_ORIGINS;
+// When ALLOWED_ORIGINS is not set, default to reflecting the request origin
+// so that same-origin requests are permitted without extra configuration.
+const allowedOrigins = envAllowedOrigins
+  ? envAllowedOrigins.split(',').map((o) => o.trim())
+  : null;
 
-const corsOptions = allowedOrigins.includes('*')
+const corsOptions = !allowedOrigins || allowedOrigins.includes('*')
   ? { origin: true }
   : {
       origin: (origin, callback) => {


### PR DESCRIPTION
## Summary
- Default CORS to reflect request origin when `ALLOWED_ORIGINS` is undefined
- Document `ALLOWED_ORIGINS` usage and default behavior

## Testing
- `npm test`
- `npm run build:css`

------
https://chatgpt.com/codex/tasks/task_e_68941d01bb808327ba4a3e44c4c6ddf1