### PR TITLE
feat: ensure stripe env vars are set

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ SERVER_URL=https://your-backend-domain
 PORT=4242
 ```
 
+- The Express server requires `STRIPE_SECRET_KEY`, `SUCCESS_URL`, and `CANCEL_URL` to be defined. The server will exit on startup if any are missing.
 - Never commit the `.env` file.
 - In production, configure these values through your hosting provider's environment settings.
 - Use the publishable key (`pk_test…`) only for client-side Stripe SDK usage when added.

--- a/server.js
+++ b/server.js
@@ -2,7 +2,16 @@ require('dotenv').config();
 const express = require('express');
 const cors = require('cors');
 const helmet = require('helmet');
-const stripe = require('stripe')(process.env.STRIPE_SECRET_KEY);
+const { STRIPE_SECRET_KEY, SUCCESS_URL, CANCEL_URL } = process.env;
+
+if (!STRIPE_SECRET_KEY || !SUCCESS_URL || !CANCEL_URL) {
+  console.error(
+    'Missing required environment variables: STRIPE_SECRET_KEY, SUCCESS_URL, and CANCEL_URL must be defined.'
+  );
+  process.exit(1);
+}
+
+const stripe = require('stripe')(STRIPE_SECRET_KEY);
 
 const rateLimit = require('express-rate-limit');
 const app = express();
@@ -56,8 +65,8 @@ app.post('/create-checkout-session', async (req, res) => {
           quantity: 1,
         },
       ],
-      success_url: process.env.SUCCESS_URL,
-      cancel_url: process.env.CANCEL_URL,
+      success_url: SUCCESS_URL,
+      cancel_url: CANCEL_URL,
       customer_email: email || undefined,
       metadata: {
         name: name || '',


### PR DESCRIPTION
## Summary
- check Stripe environment variables at startup and fail fast when missing
- use validated URLs for checkout session redirects
- document required deployment environment variables

## Testing
- `npm test`
- `npm run build:css`


------
https://chatgpt.com/codex/tasks/task_e_68941d0306388327b3df3c19be80640a