### PR TITLE
Use production API domain for configuration

### DIFF
--- a/js/config.js
+++ b/js/config.js
@@ -4,4 +4,4 @@
 // For example: 'https://api.bridgeniagara.org'
 // If your backend runs on the same domain as the static site, you can use window.location.origin.
 
-window.SERVER_URL = window.location.origin;
+window.SERVER_URL = 'https://bridgeniagara.org';


### PR DESCRIPTION
## Summary
- point donation client to production API domain

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6894bbdc3ca88327b2bd92173e24821a