### PR TITLE
Display server error message in donation alerts

### DIFF
--- a/js/donate.js
+++ b/js/donate.js
@@ -87,9 +87,13 @@ window.addEventListener('DOMContentLoaded', () => {
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(data),
       });
-      const { url } = await res.json();
-      if (url) window.location.href = url;
-      else alert('Something went wrong. Please try again.');
+      const { url, error } = await res.json();
+      if (url) {
+        window.location.href = url;
+      } else {
+        console.error('Checkout session error:', error);
+        alert(error);
+      }
     } catch (err) {
       console.error('Error:', err);
       alert('An error occurred while processing your donation.');


### PR DESCRIPTION
## Summary
- Show server error messages returned from the donation checkout endpoint
- Log server errors in console for easier debugging

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6894bbe3b96c83279c49591c10ddd893