### PR TITLE
Store form submissions and surface API messages

### DIFF
--- a/faq.html
+++ b/faq.html
@@ -115,12 +115,13 @@
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(data)
       });
+      const result = await res.json();
       if (res.ok) {
-        faqStatus.textContent = 'Thanks for your question! We will respond soon.';
+        faqStatus.textContent = result.message || 'Thanks for your question! We will respond soon.';
         faqStatus.className = 'text-green-700 mt-2';
         faqForm.reset();
       } else {
-        faqStatus.textContent = 'Submission failed. Please try again.';
+        faqStatus.textContent = result.error || 'Submission failed. Please try again.';
         faqStatus.className = 'text-red-700 mt-2';
       }
     } catch (err) {

--- a/volunteer.html
+++ b/volunteer.html
@@ -62,12 +62,13 @@
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(data)
       });
+      const result = await res.json();
       if (res.ok) {
-        volunteerStatus.textContent = 'Thank you for volunteering! We will contact you soon.';
+        volunteerStatus.textContent = result.message || 'Thank you for volunteering! We will contact you soon.';
         volunteerStatus.className = 'text-green-700 mt-2';
         volunteerForm.reset();
       } else {
-        volunteerStatus.textContent = 'Submission failed. Please try again.';
+        volunteerStatus.textContent = result.error || 'Submission failed. Please try again.';
         volunteerStatus.className = 'text-red-700 mt-2';
       }
     } catch (err) {


### PR DESCRIPTION
## Summary
- persist `/submit-form` submissions to `data/submissions.json` and return success or error JSON
- surface API feedback in volunteer and FAQ forms

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6894bbe556a48327a2e29d84e5aa6471