### PR TITLE
Add contact form with client-side validation

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -39,8 +39,82 @@
     <p><strong>Phone:</strong> (716) 531-2075</p>
     <p><strong>Email:</strong> <a href="mailto:info@bridgeniagara.org" class="text-blue-600">info@bridgeniagara.org</a></p>
   </div>
+
+  <form id="contact-form" action="/submit-form" method="POST" class="mt-8 space-y-4">
+    <div>
+      <label for="name" class="block font-medium">Name</label>
+      <input type="text" id="name" name="name" required class="w-full border px-4 py-2 rounded">
+      <p id="name-error" class="text-red-700 text-sm mt-1 hidden">Name is required.</p>
+    </div>
+    <div>
+      <label for="email" class="block font-medium">Email</label>
+      <input type="email" id="email" name="email" required class="w-full border px-4 py-2 rounded">
+      <p id="email-error" class="text-red-700 text-sm mt-1 hidden">Email is required.</p>
+    </div>
+    <div>
+      <label for="message" class="block font-medium">Message</label>
+      <textarea id="message" name="message" rows="4" class="w-full border px-4 py-2 rounded"></textarea>
+    </div>
+    <button type="submit" class="bg-green-700 hover:bg-green-800 text-white px-6 py-2 rounded">Send</button>
+  </form>
+  <p id="contact-status" class="text-sm mt-2"></p>
 </main>
 
 <div id="footer"></div>
+<script>
+  const contactForm = document.getElementById('contact-form');
+  const statusEl = document.getElementById('contact-status');
+  const nameInput = document.getElementById('name');
+  const emailInput = document.getElementById('email');
+  const nameError = document.getElementById('name-error');
+  const emailError = document.getElementById('email-error');
+
+  contactForm.addEventListener('submit', async (e) => {
+    e.preventDefault();
+    let valid = true;
+    if (!nameInput.value.trim()) {
+      nameError.classList.remove('hidden');
+      nameInput.classList.add('border-red-500');
+      valid = false;
+    } else {
+      nameError.classList.add('hidden');
+      nameInput.classList.remove('border-red-500');
+    }
+    if (!emailInput.value.trim()) {
+      emailError.classList.remove('hidden');
+      emailInput.classList.add('border-red-500');
+      valid = false;
+    } else {
+      emailError.classList.add('hidden');
+      emailInput.classList.remove('border-red-500');
+    }
+    if (!valid) return;
+    const data = {
+      name: nameInput.value.trim(),
+      email: emailInput.value.trim(),
+      message: document.getElementById('message').value.trim(),
+      formType: 'contact'
+    };
+    try {
+      const res = await fetch(contactForm.action, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(data)
+      });
+      if (res.ok) {
+        statusEl.textContent = 'Thank you for contacting us!';
+        statusEl.className = 'text-green-700 mt-2';
+        contactForm.reset();
+      } else {
+        statusEl.textContent = 'Submission failed. Please try again.';
+        statusEl.className = 'text-red-700 mt-2';
+      }
+    } catch (err) {
+      statusEl.textContent = 'An error occurred. Please try again.';
+      statusEl.className = 'text-red-700 mt-2';
+    }
+  });
+</script>
 <script src="js/header.js"></script>
+<script src="js/footer.js"></script>
 </body></html>


### PR DESCRIPTION
## Summary
- add contact form to contact page
- validate required fields and display Tailwind-styled errors
- send form submission to backend and show success or failure

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6894bbe77e308327867276e9687ac35e