### PR TITLE
Handle JSON volunteer form responses and add email validation

### DIFF
--- a/volunteer.html
+++ b/volunteer.html
@@ -50,6 +50,14 @@
   const volunteerStatus = document.getElementById('volunteer-status');
   volunteerForm.addEventListener('submit', async (e) => {
     e.preventDefault();
+    volunteerStatus.textContent = '';
+    const email = document.getElementById('email').value.trim();
+    const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+    if (!emailRegex.test(email)) {
+      volunteerStatus.textContent = 'Please enter a valid email address.';
+      volunteerStatus.className = 'text-red-700 mt-2';
+      return;
+    }
     if (!volunteerForm.checkValidity()) {
       volunteerForm.reportValidity();
       return;
@@ -62,12 +70,16 @@
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(data)
       });
+      let result = {};
+      try {
+        result = await res.json();
+      } catch (_) {}
       if (res.ok) {
-        volunteerStatus.textContent = 'Thank you for volunteering! We will contact you soon.';
+        volunteerStatus.textContent = result.message || 'Thank you for volunteering! We will contact you soon.';
         volunteerStatus.className = 'text-green-700 mt-2';
         volunteerForm.reset();
       } else {
-        volunteerStatus.textContent = 'Submission failed. Please try again.';
+        volunteerStatus.textContent = result.error || 'Submission failed. Please try again.';
         volunteerStatus.className = 'text-red-700 mt-2';
       }
     } catch (err) {


### PR DESCRIPTION
## Summary
- parse `/submit-form` responses as JSON in volunteer form
- show server error messages in #volunteer-status with Tailwind `text-red-700`
- add explicit client-side email format validation

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6894bbeac81883278509293d3ce998aa