### PR TITLE
Simplify Turkey Giveaway donation flow

### DIFF
--- a/turkey-giveaway.html
+++ b/turkey-giveaway.html
@@ -45,32 +45,17 @@
         <p>Abate Elementary School, 1600 11th St, Niagara Falls, NY 14305.</p>
       </div>
       <div>
-        <p class="font-semibold">Sponsorship Tiers:</p>
-        <ul class="list-disc pl-6">
-          <li>$2,000</li>
-          <li>$1,500</li>
-          <li>$1,000</li>
-          <li>Other amounts are welcome.</li>
-        </ul>
+        <p class="font-semibold">Donate:</p>
+        <p>Support this event through our <a href="/donate.html" class="text-green-700 underline">main donation form</a>.</p>
       </div>
     </div>
     <section class="bg-yellow-50 rounded-lg p-6 shadow text-center space-y-4">
       <h2 class="text-2xl font-semibold text-green-700">Support the Giveaway</h2>
-      <div class="flex flex-col sm:flex-row justify-center gap-4">
-        <a href="/donate.html?amount=2000" class="bg-red-600 hover:bg-red-700 text-white px-6 py-3 rounded shadow inline-flex items-center justify-center gap-2 w-full sm:w-auto transition">
-          <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8c-1.657 0-3 .895-3 2s1.343 2 3 2 3 .895 3 2-1.343 2-3 2m0-8v8m0-10v2m0 12v2" /></svg>
-          Donate $2,000
-        </a>
-        <a href="/donate.html?amount=1500" class="bg-red-600 hover:bg-red-700 text-white px-6 py-3 rounded shadow inline-flex items-center justify-center gap-2 w-full sm:w-auto transition">
-          <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8c-1.657 0-3 .895-3 2s1.343 2 3 2 3 .895 3 2-1.343 2-3 2m0-8v8m0-10v2m0 12v2" /></svg>
-          Donate $1,500
-        </a>
-        <a href="/donate.html?amount=1000" class="bg-red-600 hover:bg-red-700 text-white px-6 py-3 rounded shadow inline-flex items-center justify-center gap-2 w-full sm:w-auto transition">
-          <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8c-1.657 0-3 .895-3 2s1.343 2 3 2 3 .895 3 2-1.343 2-3 2m0-8v8m0-10v2m0 12v2" /></svg>
-          Donate $1,000
-        </a>
-      </div>
-      <p>Other amounts are welcome. <a href="/donate.html" class="text-green-700 underline">Donate another amount</a>.</p>
+      <p>All contributions are accepted through our main donation form.</p>
+      <a href="/donate.html" class="bg-red-600 hover:bg-red-700 text-white px-6 py-3 rounded shadow inline-flex items-center justify-center gap-2 w-full sm:w-auto transition">
+        <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8c-1.657 0-3 .895-3 2s1.343 2 3 2 3 .895 3 2-1.343 2-3 2m0-8v8m0-10v2m0 12v2" /></svg>
+        Donate Now
+      </a>
       <p class="text-sm text-gray-600">Donations are tax-deductible and processed securely via Stripe.</p>
     </section>
 


### PR DESCRIPTION
## Summary
- Remove sponsorship tier list and preset amount buttons from Turkey Giveaway page
- Add single Donate Now button linking to main donation form
- Clarify instructions to contribute via the main donation page

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6894bbf1eeec8327b1ca24b253fffbcf