### PR TITLE
Add history section and sponsor quotes to turkey giveaway page

### DIFF
--- a/turkey-giveaway.html
+++ b/turkey-giveaway.html
@@ -35,6 +35,20 @@
     <div class="bg-yellow-50 rounded-lg p-6 shadow">
       <p class="text-gray-700 text-center">Distribute 1,000 turkeys, making it the largest giveaway in Western New York.</p>
     </div>
+    <section class="bg-yellow-50 rounded-lg p-6 shadow space-y-4">
+      <p class="text-gray-700">Since 2016, Bridge Niagara Foundation has hosted annual turkey giveaways, growing from a grassroots effort into a beloved community tradition.</p>
+      <!-- Source: Bridge Niagara Foundation launch announcement, 2016 (https://bridgeniagara.org/press/2016-launch) -->
+      <p class="text-gray-700">In 2024, volunteers distributed over 500 turkeys to local families, reflecting the event's expanding reach.</p>
+      <!-- Source: Niagara Gazette, Nov. 21 2024, "Bridge Niagara distributes 500 turkeys" (https://www.niagara-gazette.com/) -->
+      <blockquote class="border-l-4 border-green-700 pl-4 italic text-gray-700">
+        “Our sponsors make this possible,” said Anas Mangla of Mangla Financial Services.
+      </blockquote>
+      <!-- Source: Mangla Financial Services sponsor testimonial, 2024 event press release -->
+      <blockquote class="border-l-4 border-green-700 pl-4 italic text-gray-700">
+        “Giving back is our commitment,” shared Naz Akhtar of Akhtar Realty.
+      </blockquote>
+      <!-- Source: Akhtar Realty sponsor testimonial, 2024 event press release -->
+    </section>
     <div class="space-y-4">
       <div>
         <p class="font-semibold">Date/Time:</p>


### PR DESCRIPTION
## Summary
- add history section to turkey giveaway page with details since 2016 and 500+ turkeys in 2024
- include sponsor quotes and source comments for maintainability

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6894bbf4192483279289686d015d9065