### PR TITLE
Redirect root to index.html

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -2,3 +2,8 @@
 # php -- BEGIN cPanel-generated handler, do not edit
 # This domain inherits the “PHP” package.
 # php -- END cPanel-generated handler, do not edit
+# Redirect root to index.html while preserving HTTPS and trailing slashes
+RewriteEngine On
+RewriteCond %{REQUEST_URI} ^/$
+RewriteRule ^$ index.html [L,R=301]
+


### PR DESCRIPTION
## Summary
- redirect / to /index.html via .htaccess to preserve HTTPS and trailing slashes

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6894bbf946548327ab7fc0a946c312a7