### PR TITLE
Run automated tests and enable CI on push

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,8 @@
 name: CI
 
 on:
+  push:
+    branches: ["*"]
   pull_request:
     branches: ["*"]
 

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "start": "node server.js",
     "build:css": "tailwindcss -i ./src/tailwind.css -o ./css/tailwind.css --minify",
     "build": "npm run build:css",
-    "test": "node tests/payment.test.js && node tests/server-errors.test.js && node tests/form-validation.test.js",
+    "test": "node run-tests.js",
     "lint": "eslint ."
   },
   "dependencies": {

--- a/run-tests.js
+++ b/run-tests.js
@@ -1,0 +1,16 @@
+const { spawnSync } = require('child_process');
+const fs = require('fs');
+const path = require('path');
+
+const testsDir = path.join(__dirname, 'tests');
+const testFiles = fs.readdirSync(testsDir).filter((file) => file.endsWith('.test.js'));
+
+for (const file of testFiles) {
+  const result = spawnSync('node', [path.join(testsDir, file)], {
+    stdio: 'inherit',
+    env: { ...process.env, NODE_OPTIONS: '--require=./tests/stripe-mock.js' },
+  });
+  if (result.status !== 0) {
+    process.exit(result.status);
+  }
+}

--- a/tests/payment.test.js
+++ b/tests/payment.test.js
@@ -9,8 +9,7 @@ const { spawn } = require('child_process');
       SUCCESS_URL: 'https://example.com/success',
       CANCEL_URL: 'https://example.com/cancel',
       ALLOWED_ORIGINS: '*',
-      PORT: '5555',
-      NODE_OPTIONS: '--require=./tests/stripe-mock.js'
+      PORT: '5555'
     },
     stdio: 'inherit'
   });

--- a/tests/server-errors.test.js
+++ b/tests/server-errors.test.js
@@ -8,8 +8,7 @@ const { spawn } = require('child_process');
       SUCCESS_URL: 'https://example.com/success',
       CANCEL_URL: 'https://example.com/cancel',
       ALLOWED_ORIGINS: '*',
-      PORT: '5556',
-      NODE_OPTIONS: '--require=./tests/stripe-mock.js'
+      PORT: '5556'
     },
     stdio: 'inherit'
   });


### PR DESCRIPTION
## Summary
- run every test file in `tests/` when executing `npm test`
- preload Stripe mock during tests to prevent network calls
- run GitHub Actions CI on both pushes and pull requests

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6894bbfcb98083279f4e41eae2e612df