### PR TITLE
Use root-relative paths for shared header and footer

### DIFF
--- a/js/footer.js
+++ b/js/footer.js
@@ -1,6 +1,6 @@
 // Inject shared footer on pages
 window.addEventListener('DOMContentLoaded', () => {
-  fetch('footer.html')
+  fetch('/footer.html')
     .then((response) => response.text())
     .then((html) => {
       const container = document.getElementById('footer');

--- a/js/header.js
+++ b/js/header.js
@@ -1,6 +1,6 @@
 // Inject shared header on pages
 window.addEventListener('DOMContentLoaded', () => {
-  fetch('header.html')
+  fetch('/header.html')
     .then((response) => response.text())
     .then((html) => {
       const container = document.getElementById('header');


### PR DESCRIPTION
## Summary
- Ensure header and footer scripts load shared HTML from the site root to avoid path issues on nested pages

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6894c75a0c008327849649bae7fd268b