### PR TITLE
Add basic program slider

### DIFF
--- a/js/programs.js
+++ b/js/programs.js
@@ -1,0 +1,36 @@
+// Program slider logic
+window.addEventListener('DOMContentLoaded', () => {
+  const slides = document.querySelectorAll('.program-slide');
+  let index = 0;
+
+  function showSlide(i) {
+    slides.forEach((slide, idx) => {
+      slide.classList.toggle('hidden', idx !== i);
+    });
+  }
+
+  function nextSlide() {
+    index = (index + 1) % slides.length;
+    showSlide(index);
+  }
+
+  function prevSlide() {
+    index = (index - 1 + slides.length) % slides.length;
+    showSlide(index);
+  }
+
+  if (slides.length) {
+    showSlide(index);
+    const nextBtn = document.querySelector('[data-program-next]');
+    const prevBtn = document.querySelector('[data-program-prev]');
+
+    if (nextBtn) {
+      nextBtn.addEventListener('click', nextSlide);
+    }
+    if (prevBtn) {
+      prevBtn.addEventListener('click', prevSlide);
+    }
+
+    setInterval(nextSlide, 5000);
+  }
+});

--- a/programs.html
+++ b/programs.html
@@ -121,5 +121,6 @@
   <div id="footer"></div>
   <script src="js/header.js"></script>
   <script src="js/footer.js"></script>
+  <script src="js/programs.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add program slider JavaScript that cycles through `.program-slide` items and supports optional next/prev controls
- load the slider script on `programs.html` to activate the slideshow

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6894df5c6170832784c13bd7682039a7