### PR TITLE
Add Stripe v3 script to donation page

### DIFF
--- a/donate.html
+++ b/donate.html
@@ -6,6 +6,7 @@
   <meta name="description" content="Support Bridge Niagara Foundation's programs by making a secure donation.">
   <title>Donate - Bridge Niagara Foundation</title>
   <script src="https://cdn.tailwindcss.com"></script>
+  <script src="https://js.stripe.com/v3/"></script>
   <style>
     @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;600;800&display=swap');
     body{font-family:'Inter',sans-serif;}


### PR DESCRIPTION
## Summary
- load Stripe.js v3 from official CDN in donation page head

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6895105c3f208327884df201384542be