### PR TITLE
Validate donation amount before checkout

### DIFF
--- a/js/donate.js
+++ b/js/donate.js
@@ -79,6 +79,11 @@ window.addEventListener('DOMContentLoaded', () => {
     }
     delete data.custom_amount;
 
+    if (!Number.isInteger(data.amount) || data.amount <= 0) {
+      alert('Please enter a valid donation amount.');
+      return;
+    }
+
     data.mode = data.mode === 'subscription' ? 'subscription' : 'payment';
 
     try {


### PR DESCRIPTION
## Summary
- ensure donation amount is a positive integer before creating checkout session

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6895105e6b38832783f8f76adafdcc93