### PR TITLE
Validate ALLOWED_ORIGINS for CORS

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,8 @@
+# Environment variables for Bridge Niagara server
+# ALLOWED_ORIGINS must include both https://www.bridgeniagara.org and https://bridgeniagara.org
+STRIPE_SECRET_KEY=sk_test_placeholder
+SUCCESS_URL=https://www.bridgeniagara.org/success.html
+CANCEL_URL=https://www.bridgeniagara.org/cancel.html
+SERVER_URL=https://your-backend-domain
+ALLOWED_ORIGINS=https://www.bridgeniagara.org,https://bridgeniagara.org
+PORT=4242

--- a/server.js
+++ b/server.js
@@ -3,7 +3,12 @@ const express = require('express');
 const cors = require('cors');
 const helmet = require('helmet');
 const fs = require('fs/promises');
-const { STRIPE_SECRET_KEY, SUCCESS_URL, CANCEL_URL } = process.env;
+const { STRIPE_SECRET_KEY, SUCCESS_URL, CANCEL_URL, ALLOWED_ORIGINS } = process.env;
+
+if (!ALLOWED_ORIGINS) {
+  console.error('Missing ALLOWED_ORIGINS environment variable.');
+  process.exit(1);
+}
 
 if (!STRIPE_SECRET_KEY || !SUCCESS_URL || !CANCEL_URL) {
   console.error(
@@ -21,7 +26,7 @@ const app = express();
 const limiter = rateLimit({ windowMs: 60 * 1000, max: 100 });
 app.use(limiter);
 
-const envAllowedOrigins = process.env.ALLOWED_ORIGINS;
+const envAllowedOrigins = ALLOWED_ORIGINS;
 // When ALLOWED_ORIGINS is not set, default to reflecting the request origin
 // so that same-origin requests are permitted without extra configuration.
 const allowedOrigins = envAllowedOrigins


### PR DESCRIPTION
## Summary
- require ALLOWED_ORIGINS environment variable and fail fast when missing
- drive CORS configuration from the validated ALLOWED_ORIGINS value
- document in .env that ALLOWED_ORIGINS must include both bridgeniagara.org domains

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68951060d13883278f3d9e44b29666aa