### PR TITLE
Use local Tailwind CSS

### DIFF
--- a/about.html
+++ b/about.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta name="description" content="Learn about Bridge Niagara Foundation's mission and board working to build a more connected Niagara County.">
   <title>About Us - Bridge Niagara Foundation</title>
-  <script src="https://cdn.tailwindcss.com"></script>
+  <link rel="stylesheet" href="css/tailwind.css" />
   <style>
     @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;600;800&display=swap');
     body{font-family:'Inter',sans-serif;}

--- a/contact.html
+++ b/contact.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta name="description" content="Get in touch with Bridge Niagara Foundation for questions, support, or directions to our Niagara Falls office.">
   <title>Contact Us - Bridge Niagara Foundation</title>
-  <script src="https://cdn.tailwindcss.com"></script>
+  <link rel="stylesheet" href="css/tailwind.css" />
   <style>
     @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;600;800&display=swap');
     body{font-family:'Inter',sans-serif;}

--- a/donate.html
+++ b/donate.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta name="description" content="Support Bridge Niagara Foundation's programs by making a secure donation.">
   <title>Donate - Bridge Niagara Foundation</title>
-  <script src="https://cdn.tailwindcss.com"></script>
+  <link rel="stylesheet" href="css/tailwind.css" />
   <script src="https://js.stripe.com/v3/"></script>
   <style>
     @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;600;800&display=swap');

--- a/faq.html
+++ b/faq.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta name="description" content="Frequently asked questions about Bridge Niagara Foundation's programs.">
   <title>FAQ - Bridge Niagara Foundation</title>
-  <script src="https://cdn.tailwindcss.com"></script>
+  <link rel="stylesheet" href="css/tailwind.css" />
   <style>
     @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;600;800&display=swap');
     body{font-family:'Inter',sans-serif;}

--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@
   <noscript><meta http-equiv="refresh" content="0;url=https://www.bridgeniagara.org/"></noscript>
   <script src="js/redirect.js"></script>
   <title>Bridge Niagara Foundation</title>
-  <script src="https://cdn.tailwindcss.com"></script>
+  <link rel="stylesheet" href="css/tailwind.css" />
   <style>
     @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;600;800&display=swap');
     body{font-family:'Inter',sans-serif;}

--- a/programs.html
+++ b/programs.html
@@ -5,11 +5,11 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <noscript><meta http-equiv="refresh" content="0;url=https://www.bridgeniagara.org/programs.html"></noscript>
   <script src="js/redirect.js"></script>
+  <title>Programs</title>
+  <link rel="stylesheet" href="css/tailwind.css" />
   <style>
     .hero-slide{transition:opacity 0.5s ease-in-out;}
   </style>
-  <title>Programs</title>
-  <script src="https://cdn.tailwindcss.com"></script>
 </head>
 <body class="bg-white text-gray-800">
   <div id="header"></div>

--- a/turkey-giveaway.html
+++ b/turkey-giveaway.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta name="description" content="Details about Bridge Niagara Foundation's annual Turkey Giveaway program.">
   <title>Turkey Giveaway - Bridge Niagara Foundation</title>
-  <script src="https://cdn.tailwindcss.com"></script>
+  <link rel="stylesheet" href="css/tailwind.css" />
   <style>
     @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;600;800&display=swap');
     body{font-family:'Inter',sans-serif;}

--- a/volunteer.html
+++ b/volunteer.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta name="description" content="Join Bridge Niagara Foundation as a volunteer to support community events, outreach, and youth programs across Niagara.">
   <title>Volunteer - Bridge Niagara Foundation</title>
-  <script src="https://cdn.tailwindcss.com"></script>
+  <link rel="stylesheet" href="css/tailwind.css" />
   <style>
     @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;600;800&display=swap');
     body{font-family:'Inter',sans-serif;}


### PR DESCRIPTION
## Summary
- serve Tailwind from local `css/tailwind.css` instead of remote CDN across HTML pages

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689513d995c08327915b3789accc02d7