### PR TITLE
Include bridgeniagara and www in allowed origins

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,7 +11,8 @@ CANCEL_URL=https://your-static-site-domain/cancel.html
 SERVER_URL=https://your-backend-domain
 
 # Comma-separated list of allowed origins for CORS
-ALLOWED_ORIGINS=https://your-static-site-domain
+# Must include both https://bridgeniagara.org and https://www.bridgeniagara.org
+ALLOWED_ORIGINS=https://bridgeniagara.org,https://www.bridgeniagara.org
 
 # Port for local server
 PORT=4242

--- a/server.js
+++ b/server.js
@@ -26,12 +26,23 @@ const app = express();
 const limiter = rateLimit({ windowMs: 60 * 1000, max: 100 });
 app.use(limiter);
 
+const defaultAllowedOrigins = [
+  'https://bridgeniagara.org',
+  'https://www.bridgeniagara.org',
+];
 const envAllowedOrigins = ALLOWED_ORIGINS;
 // When ALLOWED_ORIGINS is not set, default to reflecting the request origin
 // so that same-origin requests are permitted without extra configuration.
 const allowedOrigins = envAllowedOrigins
-  ? envAllowedOrigins.split(',').map((o) => o.trim())
-  : null;
+  ? Array.from(
+      new Set(
+        envAllowedOrigins
+          .split(',')
+          .map((o) => o.trim())
+          .concat(defaultAllowedOrigins)
+      )
+    )
+  : defaultAllowedOrigins;
 
 const corsOptions = !allowedOrigins || allowedOrigins.includes('*')
   ? { origin: true }


### PR DESCRIPTION
## Summary
- Ensure server defaults include both `https://bridgeniagara.org` and `https://www.bridgeniagara.org` for CORS
- Document required origins in environment example

## Testing
- `npm test`
- `npm run lint`
- `node server.js`

------
https://chatgpt.com/codex/tasks/task_e_6895163e1a9c8327ad1a345647261f59