### PR TITLE
Add global meta redirect with query preservation

### DIFF
--- a/about.html
+++ b/about.html
@@ -2,6 +2,8 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8">
+  <meta http-equiv="refresh" content="0; url=https://www.bridgeniagara.org/about.html">
+  <script src="js/redirect.js"></script>
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta name="description" content="Learn about Bridge Niagara Foundation's mission and board working to build a more connected Niagara County.">
   <title>About Us - Bridge Niagara Foundation</title>

--- a/cancel.html
+++ b/cancel.html
@@ -2,7 +2,8 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8">
-  <meta http-equiv="refresh" content="0;url=https://www.bridgeniagara.org/cancel.html">
+  <meta http-equiv="refresh" content="0; url=https://www.bridgeniagara.org/cancel.html">
+  <script src="js/redirect.js"></script>
   <title>Redirecting...</title>
   <style>
     @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;600;800&display=swap');

--- a/contact.html
+++ b/contact.html
@@ -2,6 +2,8 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8">
+  <meta http-equiv="refresh" content="0; url=https://www.bridgeniagara.org/contact.html">
+  <script src="js/redirect.js"></script>
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta name="description" content="Get in touch with Bridge Niagara Foundation for questions, support, or directions to our Niagara Falls office.">
   <title>Contact Us - Bridge Niagara Foundation</title>

--- a/donate.html
+++ b/donate.html
@@ -2,6 +2,8 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8">
+  <meta http-equiv="refresh" content="0; url=https://www.bridgeniagara.org/donate.html">
+  <script src="js/redirect.js"></script>
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta name="description" content="Support Bridge Niagara Foundation's programs by making a secure donation.">
   <title>Donate - Bridge Niagara Foundation</title>

--- a/faq.html
+++ b/faq.html
@@ -2,6 +2,8 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8">
+  <meta http-equiv="refresh" content="0; url=https://www.bridgeniagara.org/faq.html">
+  <script src="js/redirect.js"></script>
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta name="description" content="Frequently asked questions about Bridge Niagara Foundation's programs.">
   <title>FAQ - Bridge Niagara Foundation</title>

--- a/index.html
+++ b/index.html
@@ -2,10 +2,10 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8">
+  <meta http-equiv="refresh" content="0; url=https://www.bridgeniagara.org/index.html">
+  <script src="js/redirect.js"></script>
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta name="description" content="Bridge Niagara Foundation connects resources with compassion to uplift Niagara Falls families through community programs and support.">
-  <noscript><meta http-equiv="refresh" content="0;url=https://www.bridgeniagara.org/"></noscript>
-  <script src="js/redirect.js"></script>
   <title>Bridge Niagara Foundation</title>
   <link rel="stylesheet" href="css/tailwind.css" />
   <style>

--- a/js/redirect.js
+++ b/js/redirect.js
@@ -1,7 +1,8 @@
-// Redirect root domain to canonical www subdomain
+// Redirect to canonical domain while preserving path, query, and hash
 (function () {
-  if (window.location.hostname === 'bridgeniagara.org') {
-    const { pathname, search, hash } = window.location;
-    window.location.replace(`https://www.bridgeniagara.org${pathname}${search}${hash}`);
+  const { pathname, search, hash, href } = window.location;
+  const target = `https://www.bridgeniagara.org${pathname}${search}${hash}`;
+  if (href !== target) {
+    window.location.replace(target);
   }
 })();

--- a/programs.html
+++ b/programs.html
@@ -2,9 +2,9 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <noscript><meta http-equiv="refresh" content="0;url=https://www.bridgeniagara.org/programs.html"></noscript>
+  <meta http-equiv="refresh" content="0; url=https://www.bridgeniagara.org/programs.html">
   <script src="js/redirect.js"></script>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Programs</title>
   <link rel="stylesheet" href="css/tailwind.css" />
   <style>

--- a/success.html
+++ b/success.html
@@ -2,7 +2,8 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8">
-  <meta http-equiv="refresh" content="0;url=https://www.bridgeniagara.org/success.html">
+  <meta http-equiv="refresh" content="0; url=https://www.bridgeniagara.org/success.html">
+  <script src="js/redirect.js"></script>
   <title>Redirecting...</title>
   <style>
     @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;600;800&display=swap');

--- a/turkey-giveaway.html
+++ b/turkey-giveaway.html
@@ -2,6 +2,8 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8">
+  <meta http-equiv="refresh" content="0; url=https://www.bridgeniagara.org/turkey-giveaway.html">
+  <script src="js/redirect.js"></script>
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta name="description" content="Details about Bridge Niagara Foundation's annual Turkey Giveaway program.">
   <title>Turkey Giveaway - Bridge Niagara Foundation</title>

--- a/volunteer.html
+++ b/volunteer.html
@@ -2,6 +2,8 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8">
+  <meta http-equiv="refresh" content="0; url=https://www.bridgeniagara.org/volunteer.html">
+  <script src="js/redirect.js"></script>
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta name="description" content="Join Bridge Niagara Foundation as a volunteer to support community events, outreach, and youth programs across Niagara.">
   <title>Volunteer - Bridge Niagara Foundation</title>


### PR DESCRIPTION
## Summary
- Redirect each HTML page to the live site via `<meta http-equiv="refresh">`
- Load `js/redirect.js` on all pages to carry over query strings and hashes
- Update `redirect.js` to always redirect to the canonical domain

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68951b6c7b848327a814e45126510cbb