### PR TITLE
Use root-relative header links and update fetch logic

### DIFF
--- a/header.html
+++ b/header.html
@@ -1,6 +1,6 @@
 <header class="sticky top-0 bg-white/90 backdrop-blur shadow z-50">
   <div class="max-w-5xl mx-auto px-4 py-4 flex justify-between items-center relative">
-    <a href="index.html" class="flex items-center">
+    <a href="/index.html" class="flex items-center">
       <img src="images/bnf_logo.png" alt="BNF Logo" class="h-16 w-auto bg-white p-2 rounded shadow mr-3">
       <span class="text-xl font-bold text-green-700">Bridge Niagara Foundation</span>
     </a>
@@ -11,14 +11,14 @@
     </button>
     <nav id="nav-menu" class="hidden absolute top-full left-0 w-full bg-white shadow-md md:shadow-none md:bg-transparent md:static md:block">
       <ul class="flex flex-col md:flex-row gap-2 md:gap-4 text-sm md:text-base items-start md:items-center p-4 md:p-0">
-        <li><a href="index.html" class="block px-2 py-1 hover:text-green-700">Home</a></li>
-        <li><a href="about.html" class="block px-2 py-1 hover:text-green-700">About</a></li>
-        <li><a href="turkey-giveaway.html" class="block px-2 py-1 hover:text-green-700">Turkey Giveaway</a></li>
-        <li><a href="programs.html" class="block px-2 py-1 hover:text-green-700">Programs</a></li>
-        <li><a href="volunteer.html" class="block px-2 py-1 hover:text-green-700">Volunteer</a></li>
-        <li><a href="donate.html" class="block bg-red-600 hover:bg-red-700 text-white px-4 py-2 rounded shadow transition">Donate</a></li>
-        <li><a href="contact.html" class="block px-2 py-1 hover:text-green-700">Contact</a></li>
-        <li><a href="faq.html" class="block px-2 py-1 hover:text-green-700">FAQ</a></li>
+        <li><a href="/index.html" class="block px-2 py-1 hover:text-green-700">Home</a></li>
+        <li><a href="/about.html" class="block px-2 py-1 hover:text-green-700">About</a></li>
+        <li><a href="/programs.html" class="block px-2 py-1 hover:text-green-700">Programs</a></li>
+        <li><a href="/turkey-giveaway.html" class="block px-2 py-1 hover:text-green-700">Turkey Giveaway</a></li>
+        <li><a href="/volunteer.html" class="block px-2 py-1 hover:text-green-700">Volunteer</a></li>
+        <li><a href="/donate.html" class="block bg-red-600 hover:bg-red-700 text-white px-4 py-2 rounded shadow transition">Donate</a></li>
+        <li><a href="/contact.html" class="block px-2 py-1 hover:text-green-700">Contact</a></li>
+        <li><a href="/faq.html" class="block px-2 py-1 hover:text-green-700">FAQ</a></li>
       </ul>
     </nav>
   </div>

--- a/js/footer.js
+++ b/js/footer.js
@@ -1,8 +1,8 @@
 // Inject shared footer on pages
 window.addEventListener('DOMContentLoaded', () => {
-  const footerUrl = window.location.hostname.startsWith('www.')
-    ? '/footer.html'
-    : 'https://www.bridgeniagara.org/footer.html';
+  const footerUrl = window.location.hostname === 'bridgeniagara.org'
+    ? 'https://www.bridgeniagara.org/footer.html'
+    : '/footer.html';
 
   fetch(footerUrl)
     .then((response) => response.text())

--- a/js/header.js
+++ b/js/header.js
@@ -1,8 +1,8 @@
 // Inject shared header on pages
 window.addEventListener('DOMContentLoaded', () => {
-  const headerUrl = window.location.hostname.startsWith('www.')
-    ? '/header.html'
-    : 'https://www.bridgeniagara.org/header.html';
+  const headerUrl = window.location.hostname === 'bridgeniagara.org'
+    ? 'https://www.bridgeniagara.org/header.html'
+    : '/header.html';
 
   fetch(headerUrl)
     .then((response) => response.text())


### PR DESCRIPTION
## Summary
- Update header navigation to use root-relative URLs and requested order
- Load shared header/footer from https://www.bridgeniagara.org when on apex domain

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68951b6dfe848327b927884118c821cd