### PR TITLE
Add meta redirects and expand about page

### DIFF
--- a/about.html
+++ b/about.html
@@ -4,6 +4,8 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta name="description" content="Learn about Bridge Niagara Foundation's mission and board working to build a more connected Niagara County.">
+  <noscript><meta http-equiv="refresh" content="0;url=https://www.bridgeniagara.org/about.html"></noscript>
+  <script src="js/redirect.js"></script>
   <title>About Us - Bridge Niagara Foundation</title>
   <link rel="stylesheet" href="css/tailwind.css" />
   <style>
@@ -20,9 +22,34 @@
     <h1 class="text-3xl font-bold text-green-700">About Bridge Niagara Foundation</h1>
     <p class="text-gray-700">Bridge Niagara Foundation connects resources with compassion to uplift Niagara County through community programs and support. Our board and volunteers are committed to building a more just and connected community.</p>
 
-    <section class="space-y-2">
+    <section class="space-y-4" id="story">
+      <h2 class="text-2xl font-semibold text-green-700">Our Story</h2>
+      <p class="text-gray-700">Co-founders Anas Mangla and Nasreen &ldquo;Naz&rdquo; Akhtar launched Bridge Niagara after seeing the needs of families through their local businesses. Mangla operates several neighborhood ventures that create gathering spaces, while Akhtar&rsquo;s catering and event work has long supported community causes. Together they envisioned a foundation that unites small businesses and residents to lift up the city they love.</p>
+      <div class="grid md:grid-cols-2 gap-6">
+        <img src="images/BN5.jpg" alt="Founders Anas Mangla and Nasreen 'Naz' Akhtar" class="rounded-lg shadow" />
+        <img src="images/BN10.jpg" alt="Bridge Niagara community event" class="rounded-lg shadow" />
+      </div>
+    </section>
+
+    <section class="space-y-2" id="mission">
       <h2 class="text-2xl font-semibold text-green-700">Our Mission</h2>
-      <p class="text-gray-700">We strive to bridge gaps in services for families by providing food assistance, educational opportunities, and neighborhood support driven by kindness and collaboration.</p>
+      <p class="text-gray-700">The <em>Niagara Gazette</em> describes our mission as building bridges of hope by linking local businesses with families in need so every household can access food, education, and opportunity.</p>
+    </section>
+
+    <section class="space-y-2" id="vision">
+      <h2 class="text-2xl font-semibold text-green-700">Our Vision</h2>
+      <p class="text-gray-700">We envision a Niagara region where every family is empowered to thrive through shared resources and neighborly care.</p>
+    </section>
+
+    <section class="space-y-2" id="values">
+      <h2 class="text-2xl font-semibold text-green-700">Our Values</h2>
+      <ul class="list-disc list-inside text-gray-700 space-y-1">
+        <li><span class="font-semibold">Service:</span> meeting community needs with dedication.</li>
+        <li><span class="font-semibold">Compassion:</span> leading with kindness in every interaction.</li>
+        <li><span class="font-semibold">Diversity:</span> celebrating the cultures and voices of Niagara.</li>
+        <li><span class="font-semibold">Empowerment:</span> providing tools and opportunities for growth.</li>
+        <li><span class="font-semibold">Integrity:</span> acting with transparency and accountability.</li>
+      </ul>
     </section>
 
     <section class="space-y-2">
@@ -32,11 +59,6 @@
         <li>John Smith &ndash; Treasurer</li>
         <li>Maria Lopez &ndash; Secretary</li>
       </ul>
-    </section>
-
-    <section class="space-y-2">
-      <h2 class="text-2xl font-semibold text-green-700">Our Story</h2>
-      <p class="text-gray-700">Founded by neighbors in Niagara Falls, Bridge Niagara began as a small volunteer effort and has grown into a community foundation offering year-round programs like the annual Turkey Giveaway, vendor shows, art workshops, and more.</p>
     </section>
   </main>
   <div id="footer"></div>

--- a/contact.html
+++ b/contact.html
@@ -4,6 +4,8 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta name="description" content="Get in touch with Bridge Niagara Foundation for questions, support, or directions to our Niagara Falls office.">
+  <noscript><meta http-equiv="refresh" content="0;url=https://www.bridgeniagara.org/contact.html"></noscript>
+  <script src="js/redirect.js"></script>
   <title>Contact Us - Bridge Niagara Foundation</title>
   <link rel="stylesheet" href="css/tailwind.css" />
   <style>

--- a/donate.html
+++ b/donate.html
@@ -4,6 +4,8 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta name="description" content="Support Bridge Niagara Foundation's programs by making a secure donation.">
+  <noscript><meta http-equiv="refresh" content="0;url=https://www.bridgeniagara.org/donate.html"></noscript>
+  <script src="js/redirect.js"></script>
   <title>Donate - Bridge Niagara Foundation</title>
   <link rel="stylesheet" href="css/tailwind.css" />
   <script src="https://js.stripe.com/v3/"></script>

--- a/faq.html
+++ b/faq.html
@@ -4,6 +4,8 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta name="description" content="Frequently asked questions about Bridge Niagara Foundation's programs.">
+  <noscript><meta http-equiv="refresh" content="0;url=https://www.bridgeniagara.org/faq.html"></noscript>
+  <script src="js/redirect.js"></script>
   <title>FAQ - Bridge Niagara Foundation</title>
   <link rel="stylesheet" href="css/tailwind.css" />
   <style>

--- a/turkey-giveaway.html
+++ b/turkey-giveaway.html
@@ -4,6 +4,8 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta name="description" content="Details about Bridge Niagara Foundation's annual Turkey Giveaway program.">
+  <noscript><meta http-equiv="refresh" content="0;url=https://www.bridgeniagara.org/turkey-giveaway.html"></noscript>
+  <script src="js/redirect.js"></script>
   <title>Turkey Giveaway - Bridge Niagara Foundation</title>
   <link rel="stylesheet" href="css/tailwind.css" />
   <style>

--- a/volunteer.html
+++ b/volunteer.html
@@ -4,6 +4,8 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta name="description" content="Join Bridge Niagara Foundation as a volunteer to support community events, outreach, and youth programs across Niagara.">
+  <noscript><meta http-equiv="refresh" content="0;url=https://www.bridgeniagara.org/volunteer.html"></noscript>
+  <script src="js/redirect.js"></script>
   <title>Volunteer - Bridge Niagara Foundation</title>
   <link rel="stylesheet" href="css/tailwind.css" />
   <style>


### PR DESCRIPTION
## Summary
- add meta redirect and `redirect.js` to HTML heads for domain consistency
- expand About page with founders' story, Niagara Gazette mission wording, vision, and values
- include founder and event images using Tailwind layout

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68951b711944832787259ce2b7cc4db6