### PR TITLE
Drop meta refresh tags and gate redirects by hostname

### DIFF
--- a/about.html
+++ b/about.html
@@ -2,11 +2,8 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8">
-  <meta http-equiv="refresh" content="0; url=https://www.bridgeniagara.org/about.html">
-  <script src="js/redirect.js"></script>
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta name="description" content="Learn about Bridge Niagara Foundation's mission and board working to build a more connected Niagara County.">
-  <noscript><meta http-equiv="refresh" content="0;url=https://www.bridgeniagara.org/about.html"></noscript>
   <script src="js/redirect.js"></script>
   <title>About Us - Bridge Niagara Foundation</title>
   <script src="https://cdn.tailwindcss.com"></script>

--- a/cancel.html
+++ b/cancel.html
@@ -2,7 +2,6 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8">
-  <meta http-equiv="refresh" content="0; url=https://www.bridgeniagara.org/cancel.html">
   <script src="js/redirect.js"></script>
   <title>Redirecting...</title>
   <style>

--- a/contact.html
+++ b/contact.html
@@ -2,11 +2,8 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8">
-  <meta http-equiv="refresh" content="0; url=https://www.bridgeniagara.org/contact.html">
-  <script src="js/redirect.js"></script>
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta name="description" content="Get in touch with Bridge Niagara Foundation for questions, support, or directions to our Niagara Falls office.">
-  <noscript><meta http-equiv="refresh" content="0;url=https://www.bridgeniagara.org/contact.html"></noscript>
   <script src="js/redirect.js"></script>
   <title>Contact Us - Bridge Niagara Foundation</title>
   <script src="https://cdn.tailwindcss.com"></script>

--- a/donate.html
+++ b/donate.html
@@ -2,11 +2,8 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8">
-  <meta http-equiv="refresh" content="0; url=https://www.bridgeniagara.org/donate.html">
-  <script src="js/redirect.js"></script>
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta name="description" content="Support Bridge Niagara Foundation's programs by making a secure donation.">
-  <noscript><meta http-equiv="refresh" content="0;url=https://www.bridgeniagara.org/donate.html"></noscript>
   <script src="js/redirect.js"></script>
   <title>Donate - Bridge Niagara Foundation</title>
   <script src="https://cdn.tailwindcss.com"></script>

--- a/faq.html
+++ b/faq.html
@@ -2,11 +2,8 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8">
-  <meta http-equiv="refresh" content="0; url=https://www.bridgeniagara.org/faq.html">
-  <script src="js/redirect.js"></script>
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta name="description" content="Frequently asked questions about Bridge Niagara Foundation's programs.">
-  <noscript><meta http-equiv="refresh" content="0;url=https://www.bridgeniagara.org/faq.html"></noscript>
   <script src="js/redirect.js"></script>
   <title>FAQ - Bridge Niagara Foundation</title>
   <script src="https://cdn.tailwindcss.com"></script>

--- a/index.html
+++ b/index.html
@@ -2,10 +2,9 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8">
-  <meta http-equiv="refresh" content="0; url=https://www.bridgeniagara.org/index.html">
-  <script src="js/redirect.js"></script>
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta name="description" content="Bridge Niagara Foundation connects resources with compassion to uplift Niagara Falls families through community programs and support.">
+  <script src="js/redirect.js"></script>
   <title>Bridge Niagara Foundation</title>
   <script src="https://cdn.tailwindcss.com"></script>
   <style>

--- a/js/redirect.js
+++ b/js/redirect.js
@@ -1,8 +1,8 @@
 // Redirect to canonical domain while preserving path, query, and hash
 (function () {
-  const { pathname, search, hash, href } = window.location;
-  const target = `https://www.bridgeniagara.org${pathname}${search}${hash}`;
-  if (href !== target) {
+  const { hostname, pathname, search, hash } = window.location;
+  if (!hostname.startsWith('www.')) {
+    const target = `https://www.bridgeniagara.org${pathname}${search}${hash}`;
     window.location.replace(target);
   }
 })();

--- a/programs.html
+++ b/programs.html
@@ -2,9 +2,8 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8" />
-  <meta http-equiv="refresh" content="0; url=https://www.bridgeniagara.org/programs.html">
-  <script src="js/redirect.js"></script>
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <script src="js/redirect.js"></script>
   <title>Programs</title>
   <script src="https://cdn.tailwindcss.com"></script>
   <style>

--- a/success.html
+++ b/success.html
@@ -2,7 +2,6 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8">
-  <meta http-equiv="refresh" content="0; url=https://www.bridgeniagara.org/success.html">
   <script src="js/redirect.js"></script>
   <title>Redirecting...</title>
   <style>

--- a/turkey-giveaway.html
+++ b/turkey-giveaway.html
@@ -2,11 +2,8 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8">
-  <meta http-equiv="refresh" content="0; url=https://www.bridgeniagara.org/turkey-giveaway.html">
-  <script src="js/redirect.js"></script>
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta name="description" content="Details about Bridge Niagara Foundation's annual Turkey Giveaway program.">
-  <noscript><meta http-equiv="refresh" content="0;url=https://www.bridgeniagara.org/turkey-giveaway.html"></noscript>
   <script src="js/redirect.js"></script>
   <title>Turkey Giveaway - Bridge Niagara Foundation</title>
   <script src="https://cdn.tailwindcss.com"></script>

--- a/volunteer.html
+++ b/volunteer.html
@@ -2,11 +2,8 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8">
-  <meta http-equiv="refresh" content="0; url=https://www.bridgeniagara.org/volunteer.html">
-  <script src="js/redirect.js"></script>
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta name="description" content="Join Bridge Niagara Foundation as a volunteer to support community events, outreach, and youth programs across Niagara.">
-  <noscript><meta http-equiv="refresh" content="0;url=https://www.bridgeniagara.org/volunteer.html"></noscript>
   <script src="js/redirect.js"></script>
   <title>Volunteer - Bridge Niagara Foundation</title>
   <script src="https://cdn.tailwindcss.com"></script>


### PR DESCRIPTION
## Summary
- rely on redirect.js for canonical URL handling by dropping meta refresh and noscript redirects
- only redirect when hostname lacks `www.`
- include `js/redirect.js` once after the meta tags on each page

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68955c859fc08327990b410adce24785