### PR TITLE
Remove meta refresh and add responsive header/footer

### DIFF
--- a/cancel.html
+++ b/cancel.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8">
-  <meta http-equiv="refresh" content="0; url=https://www.bridgeniagara.org/cancel.html">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <script src="js/redirect.js"></script>
   <title>Redirecting...</title>
   <style>
@@ -14,6 +14,10 @@
   </style>
 </head>
 <body>
+  <div id="header"></div>
   <p>If you are not redirected, <a href="https://www.bridgeniagara.org/cancel.html">click here</a>.</p>
+  <div id="footer"></div>
+  <script src="js/header.js"></script>
+  <script src="js/footer.js"></script>
 </body>
 </html>

--- a/success.html
+++ b/success.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8">
-  <meta http-equiv="refresh" content="0; url=https://www.bridgeniagara.org/success.html">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <script src="js/redirect.js"></script>
   <title>Redirecting...</title>
   <style>
@@ -14,6 +14,10 @@
   </style>
 </head>
 <body>
+  <div id="header"></div>
   <p>If you are not redirected, <a href="https://www.bridgeniagara.org/success.html">click here</a>.</p>
+  <div id="footer"></div>
+  <script src="js/header.js"></script>
+  <script src="js/footer.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- drop meta refresh redirects from payment confirmation pages
- include viewport metadata for mobile responsiveness
- add shared header/footer divs and scripts

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68955c8c8dd48327815c8582b955acbb