### PR TITLE
feat: enable non-js donation fallback

### DIFF
--- a/donate.html
+++ b/donate.html
@@ -24,7 +24,7 @@
   <main class="max-w-lg mx-auto px-4 py-12">
     <h1 class="text-3xl font-bold text-center text-green-700 mb-6">Support Our Mission</h1>
     <p id="error-message" class="text-red-600 text-center"></p>
-    <form id="donation-form" class="space-y-4">
+    <form id="donation-form" method="POST" action="/create-checkout-session" class="space-y-4">
       <input type="hidden" id="amount" name="amount">
       <input type="hidden" id="donation-mode" name="mode" value="payment">
       <div class="flex justify-center gap-2 mb-4">


### PR DESCRIPTION
## Summary
- allow donation form to submit to `/create-checkout-session` when JavaScript is disabled

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68955c8ec0088327a3a74515c0d8848b