### PR TITLE
fix: point frontend to deployed API

### DIFF
--- a/js/config.js
+++ b/js/config.js
@@ -4,4 +4,5 @@
 // For example: 'https://api.bridgeniagara.org'
 // If your backend runs on the same domain as the static site, you can use window.location.origin.
 
-window.SERVER_URL = window.SERVER_URL || window.location.origin;
+// The deployed backend lives at a dedicated subdomain, so reference it directly.
+window.SERVER_URL = 'https://api.bridgeniagara.org';


### PR DESCRIPTION
## Summary
- hardcode donation server URL to deployed API

## Testing
- `npm test`
- `curl -s -X POST http://localhost:4242/create-checkout-session -H "Content-Type: application/json" -d '{"amount":1000,"mode":"payment","name":"Test","email":"test@example.com"}'`


------
https://chatgpt.com/codex/tasks/task_e_6895801d8aa08327bee5d98d45afc0cf