### PR TITLE
Add Stripe webhook handler for donations

### DIFF
--- a/.env
+++ b/.env
@@ -1,6 +1,7 @@
 # Environment variables for Bridge Niagara server
 # ALLOWED_ORIGINS must include both https://www.bridgeniagara.org and https://bridgeniagara.org
 STRIPE_SECRET_KEY=sk_test_placeholder
+STRIPE_WEBHOOK_SECRET=whsec_testsecret
 SUCCESS_URL=https://www.bridgeniagara.org/success.html
 CANCEL_URL=https://www.bridgeniagara.org/cancel.html
 SERVER_URL=https://your-backend-domain

--- a/.env.example
+++ b/.env.example
@@ -2,6 +2,7 @@
 
 # Stripe secret key for local development
 STRIPE_SECRET_KEY=sk_test_yourkeyhere
+STRIPE_WEBHOOK_SECRET=whsec_yourwebhooksecrethere
 
 # URLs to redirect after checkout
 SUCCESS_URL=https://your-static-site-domain/success.html


### PR DESCRIPTION
## Summary
- add Stripe webhook endpoint to verify signatures and record completed donations
- document STRIPE_WEBHOOK_SECRET environment variable

## Testing
- `STRIPE_WEBHOOK_SECRET=whsec_testsecret npm test`
- `npm run lint` *(fails: 'Swiper' is defined but never used etc.)*


------
https://chatgpt.com/codex/tasks/task_e_6895973251408327b6facf4696bf2465