### PR TITLE
Use absolute paths for data persistence

### DIFF
--- a/server.js
+++ b/server.js
@@ -3,6 +3,7 @@ const express = require('express');
 const cors = require('cors');
 const helmet = require('helmet');
 const fs = require('fs/promises');
+const path = require('path');
 const {
   STRIPE_SECRET_KEY,
   SUCCESS_URL,
@@ -80,8 +81,8 @@ app.post('/webhook', express.raw({ type: 'application/json' }), async (req, res)
     const { metadata, amount_total, id } = session;
     const donation = { metadata, amount_total, id };
     try {
-      await fs.mkdir('data', { recursive: true });
-      const filePath = 'data/donations.json';
+      await fs.mkdir(path.join(__dirname, 'data'), { recursive: true });
+      const filePath = path.join(__dirname, 'data', 'donations.json');
       let donations = [];
       try {
         const existing = await fs.readFile(filePath, 'utf8');
@@ -137,8 +138,8 @@ app.post('/create-checkout-session', async (req, res) => {
       }
     });
     try {
-      await fs.mkdir('data', { recursive: true });
-      const donationsPath = 'data/donations.json';
+      await fs.mkdir(path.join(__dirname, 'data'), { recursive: true });
+      const donationsPath = path.join(__dirname, 'data', 'donations.json');
       let donations = [];
       try {
         const existing = await fs.readFile(donationsPath, 'utf8');
@@ -182,8 +183,8 @@ app.post('/submit-form', async (req, res) => {
       date: new Date().toISOString(),
     };
 
-    await fs.mkdir('data', { recursive: true });
-    const filePath = 'data/submissions.json';
+    await fs.mkdir(path.join(__dirname, 'data'), { recursive: true });
+    const filePath = path.join(__dirname, 'data', 'submissions.json');
     let submissions = [];
     try {
       const existing = await fs.readFile(filePath, 'utf8');


### PR DESCRIPTION
## Summary
- use Node's `path` to build absolute data file paths
- replace hard-coded `data/*.json` strings with `path.join(__dirname, 'data', ...)`

## Testing
- `npm test`
- `curl -s -w "\n" -X POST http://localhost:4242/create-checkout-session -H "Content-Type: application/json" -d '{"amount":5000,"mode":"payment","name":"Alice","email":"alice@example.com"}'`
- `curl -s -w "\n" -X POST http://localhost:4242/submit-form -H "Content-Type: application/json" -d '{"name":"Bob","email":"bob@example.com"}'`
- `cat data/donations.json`
- `cat data/submissions.json`


------
https://chatgpt.com/codex/tasks/task_e_6895a71eb9a083278e9ee62b9da869cf