### PR TITLE
docs: document deployment config and ignore config

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,8 @@ ALLOWED_ORIGINS=https://your-frontend.example
 - In production, configure these values through your hosting provider's environment settings.
 - Use the publishable key (`pk_test…`) only for client-side Stripe SDK usage when added.
 - The donation page requires a valid backend URL. Copy `js/config.example.js` to `js/config.js` and
-  set `window.SERVER_URL` to match `SERVER_URL` above or define `SERVER_URL` via your build system.
+  set `window.SERVER_URL` to your backend endpoint (matching `SERVER_URL` above). The `config.js`
+  file is ignored by git and must be created per deployment.
 
 If `ALLOWED_ORIGINS` is omitted, the server will automatically allow requests from the same origin as
 the page making the request. To restrict cross-origin requests, provide a comma-separated list of

--- a/js/config.js
+++ b/js/config.js
@@ -1,8 +1,0 @@
-// Configuration for donation page
-// Define the backend URL used by donate.js and other scripts.
-// You should set this to the full URL of the Express server handling donations.
-// For example: 'https://api.bridgeniagara.org'
-// If your backend runs on the same domain as the static site, you can use window.location.origin.
-
-// The deployed backend lives at a dedicated subdomain, so reference it directly.
-window.SERVER_URL = 'https://api.bridgeniagara.org';


### PR DESCRIPTION
## Summary
- remove `js/config.js` from version control
- clarify documentation for creating `js/config.js` with `SERVER_URL`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6895a72088548327b51518fd415e7569