### PR TITLE
Validate contact form inputs

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -37,7 +37,7 @@
       </div>
       <div>
         <label for="message" class="block font-medium">Message</label>
-        <textarea id="message" name="message" rows="4" class="w-full border px-4 py-2"></textarea>
+        <textarea id="message" name="message" rows="4" class="w-full border px-4 py-2" maxlength="500"></textarea>
       </div>
       <button type="submit" class="bg-green-600 hover:bg-green-700 text-white px-6 py-2 rounded">Send</button>
     </form>
@@ -56,13 +56,20 @@
   <script>
   const contactForm = document.getElementById('contact-form');
   const contactStatus = document.getElementById('contact-status');
+  const MAX_MESSAGE_LENGTH = 500;
   contactForm.addEventListener('submit', async (e) => {
     e.preventDefault();
     contactStatus.textContent = '';
     const email = document.getElementById('email').value.trim();
+    const message = document.getElementById('message').value.trim();
     const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
     if (!emailRegex.test(email)) {
       contactStatus.textContent = 'Please enter a valid email address.';
+      contactStatus.className = 'text-red-700 mt-2';
+      return;
+    }
+    if (message.length > MAX_MESSAGE_LENGTH) {
+      contactStatus.textContent = `Message must be ${MAX_MESSAGE_LENGTH} characters or fewer.`;
       contactStatus.className = 'text-red-700 mt-2';
       return;
     }

--- a/server.js
+++ b/server.js
@@ -170,6 +170,16 @@ app.post('/submit-form', async (req, res) => {
     return res.status(400).json({ error: 'Name and email are required.' });
   }
 
+  const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+  if (!emailRegex.test(email)) {
+    return res.status(400).json({ error: 'Invalid email address.' });
+  }
+
+  const MAX_MESSAGE_LENGTH = 500;
+  if (message && message.length > MAX_MESSAGE_LENGTH) {
+    return res.status(400).json({ error: `Message must be ${MAX_MESSAGE_LENGTH} characters or fewer.` });
+  }
+
   try {
     const submission = {
       name,

--- a/volunteer.html
+++ b/volunteer.html
@@ -51,7 +51,7 @@
       </div>
       <div>
         <label for="message" class="block font-medium">Additional Comments (optional)</label>
-        <textarea id="message" name="message" rows="4" class="w-full border px-4 py-2"></textarea>
+        <textarea id="message" name="message" rows="4" class="w-full border px-4 py-2" maxlength="500"></textarea>
       </div>
       <button type="submit" class="bg-green-600 hover:bg-green-700 text-white px-6 py-2 rounded">Submit</button>
     </form>
@@ -61,14 +61,21 @@
   <script>
   const volunteerForm = document.getElementById('volunteer-form');
   const volunteerStatus = document.getElementById('volunteer-status');
+  const MAX_MESSAGE_LENGTH = 500;
   volunteerForm.addEventListener('submit', async (e) => {
     e.preventDefault();
     volunteerStatus.textContent = '';
     volunteerStatus.className = 'mt-4 hidden';
     const email = document.getElementById('email').value.trim();
+    const message = document.getElementById('message').value.trim();
     const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
     if (!emailRegex.test(email)) {
       volunteerStatus.textContent = 'Please enter a valid email address.';
+      volunteerStatus.className = 'mt-4 p-4 bg-red-100 text-red-700 rounded';
+      return;
+    }
+    if (message.length > MAX_MESSAGE_LENGTH) {
+      volunteerStatus.textContent = `Message must be ${MAX_MESSAGE_LENGTH} characters or fewer.`;
       volunteerStatus.className = 'mt-4 p-4 bg-red-100 text-red-700 rounded';
       return;
     }


### PR DESCRIPTION
## Summary
- add server-side email regex and message length validation
- enforce same validation in contact and volunteer forms

## Testing
- `npm test`
- `npm run lint` *(fails: Swiper defined but unused etc)*

------
https://chatgpt.com/codex/tasks/task_e_6895a7217fbc8327bbb63126f701bbc3