### PR TITLE
Use server-side canonical redirect

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -4,6 +4,11 @@
 # php -- END cPanel-generated handler, do not edit
 # Redirect root to index.html while preserving HTTPS and trailing slashes
 RewriteEngine On
+
+# Enforce canonical www domain
+RewriteCond %{HTTP_HOST} ^bridgeniagara\.org$ [NC]
+RewriteRule ^(.*)$ https://www.bridgeniagara.org/$1 [L,R=301]
+
 RewriteCond %{REQUEST_URI} ^/$
 RewriteRule ^$ /index.html [L,R=301]
 

--- a/about.html
+++ b/about.html
@@ -4,7 +4,6 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta name="description" content="Learn about Bridge Niagara Foundation's mission and board working to build a more connected Niagara County.">
-  <script src="js/redirect.js"></script>
   <title>About Us - Bridge Niagara Foundation</title>
   <script src="https://cdn.tailwindcss.com"></script>
   <style>

--- a/cancel.html
+++ b/cancel.html
@@ -2,7 +2,6 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8">
-  <script src="js/redirect.js"></script>
   <title>Redirecting...</title>
   <style>
     @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;600;800&display=swap');

--- a/contact.html
+++ b/contact.html
@@ -4,7 +4,6 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta name="description" content="Get in touch with Bridge Niagara Foundation for questions, support, or directions to our Niagara Falls office.">
-  <script src="js/redirect.js"></script>
   <title>Contact Us - Bridge Niagara Foundation</title>
   <script src="https://cdn.tailwindcss.com"></script>
   <style>

--- a/donate.html
+++ b/donate.html
@@ -4,7 +4,6 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta name="description" content="Support Bridge Niagara Foundation's programs by making a secure donation.">
-  <script src="js/redirect.js"></script>
   <title>Donate - Bridge Niagara Foundation</title>
   <script src="https://cdn.tailwindcss.com"></script>
   <script src="https://js.stripe.com/v3/"></script>

--- a/faq.html
+++ b/faq.html
@@ -4,7 +4,6 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta name="description" content="Frequently asked questions about Bridge Niagara Foundation's programs.">
-  <script src="js/redirect.js"></script>
   <title>FAQ - Bridge Niagara Foundation</title>
   <script src="https://cdn.tailwindcss.com"></script>
   <style>

--- a/gallery.html
+++ b/gallery.html
@@ -4,7 +4,6 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <meta name="description" content="Browse artwork from Bridge Niagara's Community Art Sessions." />
-  <script src="js/redirect.js"></script>
   <title>Community Art Gallery - Bridge Niagara Foundation</title>
   <script src="https://cdn.tailwindcss.com"></script>
   <style>

--- a/index.html
+++ b/index.html
@@ -4,7 +4,6 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta name="description" content="Bridge Niagara Foundation connects resources with compassion to uplift Niagara Falls families through community programs and support.">
-  <script src="js/redirect.js"></script>
   <title>Bridge Niagara Foundation</title>
   <script src="https://cdn.tailwindcss.com"></script>
   <style>

--- a/js/redirect.js
+++ b/js/redirect.js
@@ -1,8 +1,0 @@
-// Redirect to canonical domain while preserving path, query, and hash
-(function () {
-  const { hostname, pathname, search, hash } = window.location;
-  if (!hostname.startsWith('www.')) {
-    const target = `https://www.bridgeniagara.org${pathname}${search}${hash}`;
-    window.location.replace(target);
-  }
-})();

--- a/programs.html
+++ b/programs.html
@@ -3,7 +3,6 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <script src="js/redirect.js"></script>
   <title>Programs</title>
   <script src="https://cdn.tailwindcss.com"></script>
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/swiper@10/swiper-bundle.min.css" />

--- a/success.html
+++ b/success.html
@@ -2,7 +2,6 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8">
-  <script src="js/redirect.js"></script>
   <title>Redirecting...</title>
   <style>
     @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;600;800&display=swap');

--- a/turkey-giveaway.html
+++ b/turkey-giveaway.html
@@ -4,7 +4,6 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta name="description" content="Details about Bridge Niagara Foundation's annual Turkey Giveaway program.">
-  <script src="js/redirect.js"></script>
   <title>Turkey Giveaway - Bridge Niagara Foundation</title>
   <script src="https://cdn.tailwindcss.com"></script>
   <style>

--- a/volunteer.html
+++ b/volunteer.html
@@ -4,7 +4,6 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta name="description" content="Join Bridge Niagara Foundation as a volunteer to support community events, outreach, and youth programs across Niagara.">
-  <script src="js/redirect.js"></script>
   <title>Volunteer - Bridge Niagara Foundation</title>
   <script src="https://cdn.tailwindcss.com"></script>
   <style>


### PR DESCRIPTION
## Summary
- Redirect `bridgeniagara.org` to `www.bridgeniagara.org` via `.htaccess`
- Remove client-side redirect script from all HTML pages

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6895e88531c08327bbe46ac3d096fc8a