### PR TITLE
Require STRIPE_WEBHOOK_SECRET for webhooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Sensitive credentials should be stored in a local `.env` file which is ignored b
 
 ```
 STRIPE_SECRET_KEY=sk_test_yourkeyhere
+STRIPE_WEBHOOK_SECRET=whsec_yourwebhooksecret
 SUCCESS_URL=https://your-domain.example/success.html
 CANCEL_URL=https://your-domain.example/cancel.html
 SERVER_URL=https://your-backend-domain
@@ -23,7 +24,7 @@ PORT=4242
 ALLOWED_ORIGINS=https://your-frontend.example
 ```
 
-- The Express server requires `STRIPE_SECRET_KEY`, `SUCCESS_URL`, and `CANCEL_URL` to be defined. The server will exit on startup if any are missing.
+- The Express server requires `STRIPE_SECRET_KEY`, `SUCCESS_URL`, `CANCEL_URL`, and `STRIPE_WEBHOOK_SECRET` for webhook verification. The server will exit on startup if any are missing.
 - Never commit the `.env` file.
 - In production, configure these values through your hosting provider's environment settings.
 - Use the publishable key (`pk_test…`) only for client-side Stripe SDK usage when added.
@@ -60,7 +61,7 @@ The Stripe integration requires a running Node backend and a static host for the
 
 1. **Deploy the backend**
    - Upload `server.js` (and `package.json`) to your host and run `npm install`.
-   - Configure `STRIPE_SECRET_KEY`, `SUCCESS_URL`, `CANCEL_URL`, `SERVER_URL`, `ALLOWED_ORIGINS`, and `PORT` as environment variables.
+  - Configure `STRIPE_SECRET_KEY`, `SUCCESS_URL`, `CANCEL_URL`, `SERVER_URL`, `ALLOWED_ORIGINS`, `PORT`, and `STRIPE_WEBHOOK_SECRET` as environment variables.
    - Start the server with `npm start` or `node server.js` under a process manager such as `pm2`.
 2. **Deploy the static site**
    - Copy `js/config.example.js` to `js/config.js` on the static host.
@@ -87,7 +88,7 @@ Platform notes:
 
 ## Troubleshooting
 
-- **Server exits on startup** – Check that `STRIPE_SECRET_KEY`, `SUCCESS_URL`, and `CANCEL_URL` are present in `.env`.
+- **Server exits on startup** – Check that `STRIPE_SECRET_KEY`, `SUCCESS_URL`, `CANCEL_URL`, and `STRIPE_WEBHOOK_SECRET` are present in `.env`.
 - **CORS errors** – Ensure `ALLOWED_ORIGINS` matches the domains making requests.
 
 ## Contributing

--- a/server.js
+++ b/server.js
@@ -23,6 +23,11 @@ if (!STRIPE_SECRET_KEY || !SUCCESS_URL || !CANCEL_URL) {
   process.exit(1);
 }
 
+if (!STRIPE_WEBHOOK_SECRET) {
+  console.error('Missing STRIPE_WEBHOOK_SECRET environment variable.');
+  process.exit(1);
+}
+
 const stripe = require('stripe')(STRIPE_SECRET_KEY);
 
 const rateLimit = require('express-rate-limit');

--- a/tests/payment.test.js
+++ b/tests/payment.test.js
@@ -9,7 +9,8 @@ const { spawn } = require('child_process');
       SUCCESS_URL: 'https://example.com/success',
       CANCEL_URL: 'https://example.com/cancel',
       ALLOWED_ORIGINS: '*',
-      PORT: '5555'
+      PORT: '5555',
+      STRIPE_WEBHOOK_SECRET: 'whsec_test'
     },
     stdio: 'inherit'
   });

--- a/tests/server-errors.test.js
+++ b/tests/server-errors.test.js
@@ -8,7 +8,8 @@ const { spawn } = require('child_process');
       SUCCESS_URL: 'https://example.com/success',
       CANCEL_URL: 'https://example.com/cancel',
       ALLOWED_ORIGINS: '*',
-      PORT: '5556'
+      PORT: '5556',
+      STRIPE_WEBHOOK_SECRET: 'whsec_test'
     },
     stdio: 'inherit'
   });


### PR DESCRIPTION
## Summary
- enforce presence of STRIPE_WEBHOOK_SECRET in server startup
- document STRIPE_WEBHOOK_SECRET in README and deployment steps
- update tests to set STRIPE_WEBHOOK_SECRET

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6895ec9b775083278ded69dfa36a4a1f