### PR TITLE
docs: version config.js and update deployment instructions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,5 +7,3 @@ node_modules/
 # Other
 .DS_Store
 
-# Frontend configuration generated per deployment
-js/config.js

--- a/README.md
+++ b/README.md
@@ -27,9 +27,10 @@ ALLOWED_ORIGINS=https://your-frontend.example
 - Never commit the `.env` file.
 - In production, configure these values through your hosting provider's environment settings.
 - Use the publishable key (`pk_test…`) only for client-side Stripe SDK usage when added.
-- The donation page requires a valid backend URL. Copy `js/config.example.js` to `js/config.js` and
-  set `window.SERVER_URL` to your backend endpoint (matching `SERVER_URL` above). The `config.js`
-  file is ignored by git and must be created per deployment.
+- The donation page requires a valid backend URL. `js/config.js` is versioned with a placeholder `window.SERVER_URL`. Update this file as follows:
+  - For local development, set `window.SERVER_URL` to `http://localhost:4242` (or the port used by your local server).
+  - For production, change it to the deployed backend URL.
+  - `js/config.example.js` remains as a template for reference.
 
 If `ALLOWED_ORIGINS` is omitted, the server will automatically allow requests from the same origin as
 the page making the request. To restrict cross-origin requests, provide a comma-separated list of
@@ -63,15 +64,15 @@ The Stripe integration requires a running Node backend and a static host for the
    - Configure `STRIPE_SECRET_KEY`, `SUCCESS_URL`, `CANCEL_URL`, `SERVER_URL`, `ALLOWED_ORIGINS`, and `PORT` as environment variables.
    - Start the server with `npm start` or `node server.js` under a process manager such as `pm2`.
 2. **Deploy the static site**
-   - Copy `js/config.example.js` to `js/config.js` on the static host.
-   - Set `window.SERVER_URL` in `js/config.js` to the URL where the backend is deployed.
+   - Ensure `js/config.js` contains the correct `window.SERVER_URL` pointing to your backend.
+   - `js/config.example.js` is provided as a template if you need to recreate the file.
    - Upload the HTML and client-side JavaScript (including `js/config.js`) to your static hosting provider.
 
 Platform notes:
 
-- **Vercel** – Set environment variables in the project settings. Deploy `server.js` as a Serverless Function or run `npm start`. Ensure the static site includes a customized `js/config.js` pointing to the Vercel backend.
-- **Netlify** – Add the same environment variables in Site settings. Serve the backend via a Netlify Function or external Node server, and deploy the static files with a `js/config.js` referencing it.
-- **cPanel or traditional hosting** – Upload the repository, install dependencies, configure the environment variables in the control panel, and run `node server.js` with `pm2`. Create `js/config.js` on the static portion of the site pointing to that server.
+- **Vercel** – Set environment variables in the project settings. Deploy `server.js` as a Serverless Function or run `npm start`. Ensure `js/config.js` points to the Vercel backend.
+- **Netlify** – Add the same environment variables in Site settings. Serve the backend via a Netlify Function or external Node server, and commit `js/config.js` with the backend URL.
+- **cPanel or traditional hosting** – Upload the repository, install dependencies, configure the environment variables in the control panel, and run `node server.js` with `pm2`. Ensure `js/config.js` points to that server.
 
 ### Verifying the Stripe Endpoint
 

--- a/js/config.js
+++ b/js/config.js
@@ -1,0 +1,2 @@
+// Update this to your backend endpoint
+window.SERVER_URL = 'https://your-backend-domain';


### PR DESCRIPTION
## Summary
- Track `js/config.js` with placeholder `window.SERVER_URL`
- Update environment variable and deployment docs to explain editing `window.SERVER_URL` for local and production
- Clarify that `config.example.js` remains a template

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6895ec9ca6ac8327868360cb1f5fed7c