### PR TITLE
Allow server start without ALLOWED_ORIGINS

### DIFF
--- a/server.js
+++ b/server.js
@@ -12,8 +12,7 @@ const {
 } = process.env;
 
 if (!ALLOWED_ORIGINS) {
-  console.error('Missing ALLOWED_ORIGINS environment variable.');
-  process.exit(1);
+  console.warn('ALLOWED_ORIGINS not set; using default origin list.');
 }
 
 if (!STRIPE_SECRET_KEY || !SUCCESS_URL || !CANCEL_URL) {
@@ -42,8 +41,7 @@ const defaultAllowedOrigins = [
   'https://www.bridgeniagara.org',
 ];
 const envAllowedOrigins = ALLOWED_ORIGINS;
-// When ALLOWED_ORIGINS is not set, default to reflecting the request origin
-// so that same-origin requests are permitted without extra configuration.
+// When ALLOWED_ORIGINS is not set, fall back to the default list above.
 const allowedOrigins = envAllowedOrigins
   ? Array.from(
       new Set(

--- a/tests/startup-no-allowed-origins.test.js
+++ b/tests/startup-no-allowed-origins.test.js
@@ -1,0 +1,33 @@
+const { spawn } = require('child_process');
+
+(async () => {
+  const env = {
+    ...process.env,
+    STRIPE_SECRET_KEY: process.env.STRIPE_SECRET_KEY || 'sk_test_4eC39HqLyjWDarjtT1zdp7dc',
+    SUCCESS_URL: 'https://example.com/success',
+    CANCEL_URL: 'https://example.com/cancel',
+    PORT: '5557',
+    STRIPE_WEBHOOK_SECRET: 'whsec_test'
+  };
+  delete env.ALLOWED_ORIGINS;
+
+  const server = spawn('node', ['server.js'], {
+    env,
+    stdio: 'inherit'
+  });
+
+  await new Promise(resolve => setTimeout(resolve, 2000));
+
+  try {
+    const response = await fetch('http://localhost:5557/config');
+    if (response.status !== 200) {
+      throw new Error(`Expected 200 from /config, got ${response.status}`);
+    }
+    console.log('Test passed: Server starts without ALLOWED_ORIGINS');
+  } catch (err) {
+    console.error('Test failed:', err);
+    process.exitCode = 1;
+  } finally {
+    server.kill();
+  }
+})();


### PR DESCRIPTION
## Summary
- Remove fatal check for missing ALLOWED_ORIGINS and default to built-in origin list
- Add test ensuring the server starts when ALLOWED_ORIGINS is unset

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6895f3cff8d083279e9af39eeb65888c