### PR TITLE
Document donation backend and update donation form

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,15 @@
 
 This repository contains static site assets for Bridge Niagara.
 
+## Donation Workflow
+
+The donation page runs on a static front end but relies on a separate Node/Express backend
+(`server.js`) to create Stripe Checkout sessions and log donor data. The client loads
+`js/config.js`, which sets `window.SERVER_URL` to the deployed backend's base URL. GitHub
+Pages does not serve `.mjs` files with the correct MIME type, so all modules use the `.js`
+extension. When deploying, ensure `bridgeniagara.org` and `www.bridgeniagara.org` serve the
+same content or that one permanently redirects to the other.
+
 ## Installing Dependencies
 
 Install the required Node.js packages:
@@ -44,6 +53,19 @@ node server.js
 ```
 
 `npm start` is also available as a shortcut.
+
+### Testing Donations
+
+Serve the static files in a separate terminal:
+
+```
+npx serve .
+```
+
+Visit `http://localhost:3000/donate.html`, choose an amount, and donate using Stripe's
+test card `4242 4242 4242 4242` with any future expiration date and CVC. After the
+payment completes, you will be redirected to `success.html`, and the backend will append
+the transaction to `data/donations.json` once the webhook fires.
 
 ## Running Tests
 

--- a/donate.html
+++ b/donate.html
@@ -39,12 +39,25 @@
         <label class="block mb-1" for="custom_amount">Custom amount</label>
         <input type="number" name="custom_amount" class="w-full border p-2 rounded" min="1" step="0.01" placeholder="USD">
       </div>
+      <div>
+        <label class="block mb-1" for="name">Name</label>
+        <input type="text" name="name" class="w-full border p-2 rounded" required>
+      </div>
+      <div>
+        <label class="block mb-1" for="email">Email</label>
+        <input type="email" name="email" class="w-full border p-2 rounded" required>
+      </div>
+      <div>
+        <label class="block mb-1" for="phone">Phone</label>
+        <input type="tel" name="phone" class="w-full border p-2 rounded">
+      </div>
       <button type="submit" class="donate-btn w-full">Donate with Stripe</button>
     </form>
     <p class="text-sm text-gray-600 mt-4 text-center">Donations are tax-deductible and receipts will be emailed.</p>
   </main>
   <div id="footer"></div>
   <script src="js/config.js"></script>
+  <script type="module" src="js/donationHelpers.js"></script>
   <script type="module" src="js/donate.js"></script>
   <script src="js/header.js"></script>
   <script src="js/footer.js"></script>

--- a/js/config.js
+++ b/js/config.js
@@ -1,1 +1,2 @@
+// Base URL of your donation API. Update after you deploy the server.
 window.SERVER_URL = 'https://api.bridgeniagara.org';


### PR DESCRIPTION
## Summary
- Add donor info fields and explicit module loading on donation page
- Clarify API base URL configuration
- Document Node backend workflow and Stripe testing steps

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6895f9b50090832790062980a592d3ba