### PR TITLE
Validate checkout session input

### DIFF
--- a/server.js
+++ b/server.js
@@ -116,6 +116,18 @@ app.get('/config', (req, res) => {
 app.post('/create-checkout-session', async (req, res) => {
   try {
     const { amount, mode, name, email, phone } = req.body;
+
+    if (!name || !email) {
+      return res.status(400).json({ error: 'Name and email are required.' });
+    }
+
+    const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+    if (!emailRegex.test(email)) {
+      return res.status(400).json({ error: 'Invalid email address.' });
+    }
+
+    const sanitizedPhone = phone ? phone.replace(/\D/g, '') : '';
+
     const donationAmount = parseInt(amount, 10);
     if (!Number.isInteger(donationAmount) || donationAmount <= 0) {
       return res.status(400).json({ error: 'Invalid donation amount' });
@@ -135,11 +147,11 @@ app.post('/create-checkout-session', async (req, res) => {
       ],
       success_url: SUCCESS_URL,
       cancel_url: CANCEL_URL,
-      customer_email: email || undefined,
+      customer_email: email,
       metadata: {
-        name: name || '',
-        email: email || '',
-        phone: phone || ''
+        name,
+        email,
+        phone: sanitizedPhone
       }
     });
 

--- a/tests/payment.test.js
+++ b/tests/payment.test.js
@@ -22,7 +22,7 @@ const { spawn } = require('child_process');
     const response = await fetch('http://localhost:5555/create-checkout-session', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ amount: 1000 })
+      body: JSON.stringify({ amount: 1000, name: 'Test User', email: 'test@example.com', phone: '123-456-7890' })
     });
 
     if (!response.ok) {

--- a/tests/server-errors.test.js
+++ b/tests/server-errors.test.js
@@ -21,7 +21,7 @@ const { spawn } = require('child_process');
     let response = await fetch('http://localhost:5556/create-checkout-session', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ amount: -100 })
+      body: JSON.stringify({ amount: -100, name: 'Test User', email: 'test@example.com' })
     });
     if (response.status !== 400) {
       throw new Error(`Expected 400 for invalid amount, got ${response.status}`);
@@ -35,11 +35,31 @@ const { spawn } = require('child_process');
     response = await fetch('http://localhost:5556/create-checkout-session', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ amount: 999 })
+      body: JSON.stringify({ amount: 999, name: 'Test User', email: 'test@example.com' })
     });
     if (response.status !== 500) {
       throw new Error(`Expected 500 when Stripe fails, got ${response.status}`);
     }
+    // Missing name should return 400
+    response = await fetch('http://localhost:5556/create-checkout-session', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ amount: 1000, email: 'test@example.com' })
+    });
+    if (response.status !== 400) {
+      throw new Error(`Expected 400 for missing name, got ${response.status}`);
+    }
+
+    // Invalid email should return 400
+    response = await fetch('http://localhost:5556/create-checkout-session', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ amount: 1000, name: 'Test User', email: 'invalid-email' })
+    });
+    if (response.status !== 400) {
+      throw new Error(`Expected 400 for invalid email, got ${response.status}`);
+    }
+
     console.log('Test passed: Server error cases handled');
   } catch (err) {
     console.error('Test failed:', err);


### PR DESCRIPTION
## Summary
- enforce required name and email for checkout sessions
- validate email with regex and sanitize phone number
- update tests to cover new validation requirements

## Testing
- `node run-tests.js`


------
https://chatgpt.com/codex/tasks/task_e_689606dda34c8327a67c86f92d45b513