### PR TITLE
Use DEPLOY_PATH variable in cPanel config

### DIFF
--- a/.cpanel.yml
+++ b/.cpanel.yml
@@ -1,5 +1,5 @@
 ---
 deployment:
   tasks:
-    - export DEPLOYPATH=/home/3cserve/public_html/bridgeniagara
-    - /usr/bin/rsync -a --exclude '.git*' $PWD/ $DEPLOYPATH
+    - export DEPLOY_PATH=/home/3cserve/public_html/bridgeniagara
+    - /usr/bin/rsync -a --exclude '.git*' $PWD/ $DEPLOY_PATH


### PR DESCRIPTION
## Summary
- export `DEPLOY_PATH` in cPanel deployment config and update task references

## Testing
- `yamllint .cpanel.yml`
- `npm test`
- `npm run lint`
- `rsync -av --exclude '.git*' --dry-run $PWD/ $DEPLOY_PATH | head`

------
https://chatgpt.com/codex/tasks/task_e_6896169421cc83279b1707c965ea7ef0