### PR TITLE
Add Django URL routes and stub views

### DIFF
--- a/bridgeniagara/urls.py
+++ b/bridgeniagara/urls.py
@@ -1,0 +1,16 @@
+from django.urls import path
+from core import views
+
+urlpatterns = [
+    path('', views.index, name='index'),
+    path('about/', views.about, name='about'),
+    path('programs/', views.programs, name='programs'),
+    path('turkey-giveaway/', views.turkey_giveaway, name='turkey_giveaway'),
+    path('donate/', views.donate, name='donate'),
+    path('success/', views.success, name='success'),
+    path('cancel/', views.cancel, name='cancel'),
+    path('volunteer/', views.volunteer, name='volunteer'),
+    path('contact/', views.contact, name='contact'),
+    path('faq/', views.faq, name='faq'),
+    path('create-checkout-session/', views.create_checkout_session, name='create_checkout_session'),
+]

--- a/core/views.py
+++ b/core/views.py
@@ -1,0 +1,48 @@
+from django.http import JsonResponse
+from django.shortcuts import render
+from django.views.decorators.csrf import csrf_protect
+
+
+def index(request):
+    return render(request, 'index.html')
+
+
+def about(request):
+    return render(request, 'about.html')
+
+
+def programs(request):
+    return render(request, 'programs.html')
+
+
+def turkey_giveaway(request):
+    return render(request, 'turkey-giveaway.html')
+
+
+def donate(request):
+    return render(request, 'donate.html')
+
+
+def success(request):
+    return render(request, 'success.html')
+
+
+def cancel(request):
+    return render(request, 'cancel.html')
+
+
+def volunteer(request):
+    return render(request, 'volunteer.html')
+
+
+def contact(request):
+    return render(request, 'contact.html')
+
+
+def faq(request):
+    return render(request, 'faq.html')
+
+
+@csrf_protect
+def create_checkout_session(request):
+    return JsonResponse({'url': '#'})


### PR DESCRIPTION
## Summary
- Define URL patterns for core site pages and checkout session endpoint
- Implement placeholder views that render templates and a CSRF-protected checkout session stub

## Testing
- `python -m py_compile bridgeniagara/urls.py core/views.py`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6896313bc1c48327af75c6fbc81ee59f