### PR TITLE
Configure MySQL database settings for Django

### DIFF
--- a/bridgeniagara/__init__.py
+++ b/bridgeniagara/__init__.py
@@ -1,0 +1,2 @@
+import pymysql
+pymysql.install_as_MySQLdb()

--- a/bridgeniagara/settings.py
+++ b/bridgeniagara/settings.py
@@ -1,0 +1,12 @@
+import os
+
+DATABASES = {
+    'default': {
+        'ENGINE': 'django.db.backends.mysql',
+        'NAME': os.getenv('DB_NAME', ''),
+        'USER': os.getenv('DB_USER', ''),
+        'PASSWORD': os.getenv('DB_PASSWORD', ''),
+        'HOST': os.getenv('DB_HOST', 'localhost'),
+        'PORT': os.getenv('DB_PORT', '3306'),
+    }
+}


### PR DESCRIPTION
## Summary
- add PyMySQL MySQLdb shim in `bridgeniagara/__init__.py`
- configure Django DATABASES for MySQL via environment variables

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68963139d03483278ef3ecc017aee33b