### PR TITLE
Add Passenger WSGI entrypoint for Django

### DIFF
--- a/passenger_wsgi.py
+++ b/passenger_wsgi.py
@@ -1,0 +1,5 @@
+import os, sys
+sys.path.append(os.path.dirname(os.path.abspath(__file__)))
+os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'bridgeniagara.settings')
+from django.core.wsgi import get_wsgi_application
+application = get_wsgi_application()


### PR DESCRIPTION
## Summary
- add `passenger_wsgi.py` to set up Django WSGI application for Passenger

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6896314d25c88327833761d12b7aed15